### PR TITLE
docs: add agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2025-02-11 -->
+
+## Overview
+- This repository hosts the webtrees fan chart module; this file sets global defaults and indexes scoped instructions (nearest AGENTS.md takes precedence).
+- Decision Log:
+  - 2025-02-11: Added AGENTS.md scaffolding and documented required composer checks before commits.
+  - 2025-02-11: No pull request template found in .github; PR bodies should still include the required milestone heading.
+- Scoped guides: see [src/AGENTS.md](src/AGENTS.md) for PHP code and [resources/AGENTS.md](resources/AGENTS.md) for assets.
+
+## Setup/env
+- PHP 8.3+ with extensions dom and json is required; composer installs dependencies into .build/vendor and binaries into .build/bin.
+- Node.js tooling is used for asset builds (rollup). Install dev dependencies via `npm install` when touching frontend resources.
+- Prefer running composer/npm commands inside the repository root so paths and caches resolve correctly.
+
+## Build & tests
+- Before every commit run: `composer ci:test:php:unit:coverage`, `composer ci:test:php:phpstan`, and `composer ci:cgl`; fix any findings and keep coverage at or above 90%.
+- For quick checks, use `composer ci:test:php:unit` for targeted unit feedback and `composer ci:test:php:lint` for syntax validation.
+- Asset changes should be validated with `npm run prepare` (build) or `npm run watch` during development.
+
+## Code style
+- Follow PSR-12, strict types, KISS, SOLID, DRY, YAGNI, GRASP, Law of Demeter, SoC, and convention over configuration.
+- Keep one class per PHP file with meaningful names; add English PHPDoc for every class and method describing intent and parameters.
+- Avoid mixed types, `empty()`, nested ternaries, redundant casts/braces, and dynamic static calls; prefer array helpers like `array_find`/`array_any`.
+
+## Security
+- Do not commit secrets or PII; rely on secret managers and keep .build outputs out of version control.
+- Update documentation and AGENTS.md files when behavior or configuration affecting security changes.
+
+## PR/commit checklist
+- Use Conventional Commits; include ticket IDs in titles when available.
+- Keep PRs small and focused (~≤300 net LOC) with atomic commits; ensure coverage ≥90% on touched PHP paths.
+- Prepare PR bodies with the `M# Sweep — Verify compliance for this milestone` heading above the default template content.
+
+## Good vs bad examples
+- Good: `readonly class ExampleService { /** ... */ public function handle(Request $request): Response { /* ... */ } }`
+- Good: `if (array_any($items, static fn ($item): bool => $item->isActive())) { /* ... */ }`
+- Bad: `class example { function run($x){ if(empty($x)) return; } } // no types/docs, uses empty()`
+
+## When stuck
+- Check composer scripts (`composer run-script --list`) and the README for expected workflows; align new guidance with existing tooling.
+- Document deviations or new requirements in the Decision Log of the nearest AGENTS.md.
+
+## House Rules
+- Maintain strict typing and PHPStan level max alignment; update Rector or coding-standard configs when code style shifts.
+- Prefer interfaces where sensible; mark data-only classes as `readonly` and remove redundant modifiers or arguments.
+- Always update AGENTS.md files alongside behavior changes to avoid instruction drift.

--- a/resources/AGENTS.md
+++ b/resources/AGENTS.md
@@ -1,0 +1,37 @@
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2025-02-11 -->
+
+## Overview
+- Instructions for assets under `resources/` (JS, CSS, translations, views).
+- Decision Log:
+  - 2025-02-11: Documented rollup-based build steps and alignment with PHP module guidelines for assets.
+
+## Setup/env
+- Install Node.js dependencies with `npm install`; rollup configuration lives in `rollup.config.js` and uses ES modules.
+- Keep D3-related packages and rollup plugins in sync with package.json; avoid switching package managers.
+
+## Build & tests
+- Build assets via `npm run prepare`; use `npm run watch` while developing to mirror rollup bundling.
+- Run `composer ci:test:php:unit:coverage`, `composer ci:test:php:phpstan`, and `composer ci:cgl` before commits when asset changes accompany PHP updates.
+- For static assets, prefer linting via rollup warnings; keep generated artifacts out of version control unless explicitly required.
+
+## Code style
+- Use modern ES modules and avoid nested ternaries; prefer small, pure functions and descriptive naming.
+- Keep translations and templates consistent with PHP naming; avoid embedding secrets or API keys in client code.
+
+## Security
+- Do not bundle secrets; sanitize user-provided data before rendering and avoid logging sensitive values in the browser.
+
+## PR/commit checklist
+- Verify rollup builds succeed and outputs load without console errors.
+- Keep changes minimal and aligned with PHP module behavior; commit messages follow Conventional Commits with ticket IDs when available.
+
+## Good vs bad examples
+- Good: `const visibleIndividuals = nodes.filter((node) => node.visible);`
+- Bad: `for (let i in nodes) { if (!nodes[i]) continue; /* ... complex nested ternary ... */ } // avoid for-in on arrays and nested ternaries`
+
+## When stuck
+- Review `rollup.config.js` and existing modules under `resources/js` for patterns; cross-check with README for expected asset locations.
+- Capture new conventions or deviations in the Decision Log above.
+
+## House Rules
+- Keep assets lightweight and accessible; aim for WCAG 2.2 AA where applicable and avoid unused bundles.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,43 @@
+<!-- Managed by agent: keep sections & order; edit content, not structure. Last updated: 2025-02-11 -->
+
+## Overview
+- Guidance for PHP source under `src/`; follow this when adding modules, facades, models, and traits.
+- Decision Log:
+  - 2025-02-11: Captured PHP 8.3+ constraints, strict typing, and required composer checks/coverage for backend code.
+
+## Setup/env
+- Ensure PHP 8.3+ with required extensions (dom, json) and composer dependencies installed (`composer install`).
+- Autoloading uses PSR-4 root `MagicSunday\\Webtrees\\FanChart\\`; keep namespaces aligned with folder structure.
+
+## Build & tests
+- Mandatory before committing: `composer ci:test:php:unit:coverage`, `composer ci:test:php:phpstan`, `composer ci:cgl`.
+- During development, run `composer ci:test:php:unit -- --filter <TestName>` for focused suites; keep tests mirroring `src/` structure.
+- Favor TDD for fixes: add/adjust PHPUnit 12 attribute-based tests that assert expected behaviors and keep coverage ≥90% on touched code.
+
+## Code style
+- PSR-12 with `declare(strict_types=1);` at the top of every file; one class per file with expressive names.
+- Provide PHPDoc blocks (English) for every class and method, describing purpose and parameters/return types; avoid `@deprecated`—remove dead code instead.
+- Avoid mixed types, `empty()`, nested ternaries, dynamic static calls, redundant casts/braces, and redundant arguments; prefer `array_find`/`array_any` over manual loops where applicable.
+- Use interfaces where sensible, mark data-only classes as `readonly`, remove redundant `readonly` keywords, and import fully-qualified references instead of repeated qualifiers.
+- Prevent null dereferences by validating nullable inputs; use constants with meaningful identifiers.
+
+## Security
+- Keep business logic free of secrets; validate and sanitize inputs where applicable, and avoid logging sensitive data.
+
+## PR/commit checklist
+- Confirm max-level PHPStan passes on changed code and that Rector/coding standards stay aligned with repo configs.
+- Ensure new classes ship with PHPUnit tests in matching namespaces and directories (e.g., `tests/Facade/...` mirroring `src/Facade/...`).
+- Use Conventional Commits with ticket IDs when available; keep changes cohesive and minimal.
+
+## Good vs bad examples
+- Good: `readonly class FanChartConfig implements ConfigInterface { /** Configure default radius. */ public function radius(): int { return self::DEFAULT_RADIUS; } }`
+- Good: `return array_find($pedigrees, static fn (Pedigree $pedigree): bool => $pedigree->isRoot());`
+- Bad: `class config { public function r($x){ if(empty($x)) return null; return $x ? $x : 0; } } // no types/docs, empty(), nested ternary style`
+
+## When stuck
+- Check phpstan.neon, phpunit.xml, and rector.php for expectations; align new code with existing patterns in `src/` and mirror them in tests.
+- Document notable deviations in the Decision Log above to keep instructions current.
+
+## House Rules
+- Target ≥90% coverage on touched files; prefer composition and clear separation of concerns.
+- Avoid unused code paths—remove redundant methods/classes rather than leaving them dormant.


### PR DESCRIPTION
M# Sweep — Verify compliance for this milestone

## Summary
- add AGENTS.md scaffolding at the repository root with global defaults and index entries
- add scoped AGENTS.md guidance for PHP sources under src/
- add scoped AGENTS.md guidance for assets under resources/

## Testing
- composer ci:test:php:unit:coverage *(fails: no code coverage driver available; no tests executed)*
- composer ci:test:php:phpstan *(fails: pre-existing issues in src/Facade/DataFacade.php and src/Traits/ModuleCustomTrait.php)*
- composer ci:cgl


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921b5f5c7a08323b4e89e140288f7ad)