### PR TITLE
Automate export regression build

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -2,6 +2,7 @@ export default {
     moduleNameMapper: {
         "^resources/js/modules/(.*)$": "<rootDir>/resources/js/modules/$1"
     },
+    globalSetup: "<rootDir>/resources/js/tests/globalSetup.js",
     setupFilesAfterEnv: ["<rootDir>/resources/js/tests/setup.js"],
     testEnvironment: "jsdom",
     transform: {}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "prepare": "rollup --config rollup.config.js",
         "watch": "rollup --watch --config rollup.config.js",
         "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --passWithNoTests",
+        "test:exports": "node --experimental-vm-modules node_modules/jest/bin/jest.js --runTestsByPath resources/js/tests/export.integration.test.js resources/js/tests/export.large.integration.test.js",
         "test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch"
     },
     "devDependencies": {

--- a/resources/js/tests/globalSetup.js
+++ b/resources/js/tests/globalSetup.js
@@ -1,0 +1,23 @@
+import { execSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, "../../..");
+const SHOULD_SKIP_BUILD = process.env.SKIP_EXPORT_BUILD === "true";
+
+const runBuild = () => {
+    execSync("npm run prepare", {
+        cwd: ROOT_DIR,
+        stdio: "inherit",
+    });
+};
+
+export default async () => {
+    if (SHOULD_SKIP_BUILD) {
+        return;
+    }
+
+    runBuild();
+};


### PR DESCRIPTION
M# Sweep — Verify compliance for this milestone

## Summary
- Ensure the Jest export regression suite builds the current fan chart bundle before running.
- Add an npm helper script to invoke the Playwright export regression tests directly.

## Testing
- npm run test:exports
- composer ci:test:php:unit:coverage (fails: test directory missing)
- composer ci:test:php:phpstan (fails: tests directory missing)
- composer ci:cgl (fails: tests directory missing)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69220c1858b083238d70434fc12a1c9f)