### PR TITLE
Add svg geometry and text unit tests

### DIFF
--- a/resources/js/tests/modules/custom/svg/geometry.test.js
+++ b/resources/js/tests/modules/custom/svg/geometry.test.js
@@ -1,0 +1,103 @@
+import { jest } from "@jest/globals";
+
+const scaleLinearMock = jest.fn(() => {
+    let domain = [0, 1];
+    let range = [0, 1];
+
+    const scale = (value) => {
+        const [domainStart, domainEnd] = domain;
+        const [rangeStart, rangeEnd] = range;
+        const t = (value - domainStart) / (domainEnd - domainStart);
+
+        return rangeStart + ((rangeEnd - rangeStart) * t);
+    };
+
+    scale.range = (values) => {
+        range = values;
+        return scale;
+    };
+
+    scale.domain = (values) => {
+        domain = values;
+        return scale;
+    };
+
+    return scale;
+});
+
+await jest.unstable_mockModule("resources/js/modules/lib/d3", () => ({
+    __esModule: true,
+    scaleLinear: scaleLinearMock
+}));
+
+const { default: Geometry, MATH_DEG2RAD } = await import("resources/js/modules/custom/svg/geometry");
+
+describe("Geometry", () => {
+    const createConfiguration = (overrides = {}) => ({
+        fanDegree: 180,
+        numberOfInnerCircles: 2,
+        innerArcHeight: 20,
+        outerArcHeight: 30,
+        centerCircleRadius: 50,
+        circlePadding: 10,
+        padAngle: 0,
+        padRadius: 0,
+        padDistance: 0,
+        colorArcWidth: 20,
+        ...overrides
+    });
+
+    beforeEach(() => {
+        scaleLinearMock.mockClear();
+    });
+
+    it("calculates start and end angles in radians", () => {
+        const quarterConfiguration = createConfiguration({ fanDegree: 90 });
+        const halfCircleConfiguration = createConfiguration({ fanDegree: 210 });
+
+        const quarterGeometry = new Geometry(quarterConfiguration);
+        const halfCircleGeometry = new Geometry(halfCircleConfiguration);
+
+        expect(quarterGeometry.startPi).toBe(0);
+        expect(quarterGeometry.endPi).toBeCloseTo(Math.PI / 2);
+        expect(halfCircleGeometry.startPi).toBeCloseTo(-(105 * MATH_DEG2RAD));
+        expect(halfCircleGeometry.endPi).toBeCloseTo(105 * MATH_DEG2RAD);
+    });
+
+    it("derives radii for inner, outer, center, and relative positions", () => {
+        const geometry = new Geometry(createConfiguration());
+
+        expect(geometry.innerRadius(0)).toBe(0);
+        expect(geometry.outerRadius(0)).toBe(50);
+        expect(geometry.innerRadius(1)).toBe(60);
+        expect(geometry.outerRadius(1)).toBe(70);
+        expect(geometry.centerRadius(1)).toBe(65);
+        expect(geometry.innerRadius(3)).toBe(100);
+        expect(geometry.outerRadius(3)).toBe(120);
+        expect(geometry.relativeRadius(3, 50)).toBeCloseTo(110);
+    });
+
+    it("clamps calculated angles to the configured span", () => {
+        const geometry = new Geometry(createConfiguration({ fanDegree: 120 }));
+
+        const expectedStart = -(60 * MATH_DEG2RAD);
+        const expectedEnd = 60 * MATH_DEG2RAD;
+
+        expect(geometry.calcAngle(-0.5)).toBeCloseTo(expectedStart);
+        expect(geometry.calcAngle(0.5)).toBeCloseTo(0);
+        expect(geometry.calcAngle(1.5)).toBeCloseTo(expectedEnd);
+    });
+
+    it("computes arc length for datum and position", () => {
+        const geometry = new Geometry(createConfiguration({ fanDegree: 120 }));
+        const datum = { depth: 1, x0: 0, x1: 1 };
+        const length = geometry.arcLength(datum, 50);
+
+        const span = 120 * MATH_DEG2RAD;
+        const inner = geometry.innerRadius(datum.depth);
+        const outer = geometry.outerRadius(datum.depth);
+        const relative = outer - ((100 - 50) * (outer - inner) / 100);
+
+        expect(length).toBeCloseTo(span * relative);
+    });
+});

--- a/resources/js/tests/modules/custom/svg/text.test.js
+++ b/resources/js/tests/modules/custom/svg/text.test.js
@@ -1,0 +1,177 @@
+import { jest } from "@jest/globals";
+
+const measureTextMock = jest.fn((text) => text.length * 10);
+
+const scaleLinearMock = jest.fn(() => {
+    let domain = [0, 1];
+    let range = [0, 1];
+
+    const scale = (value) => {
+        const [domainStart, domainEnd] = domain;
+        const [rangeStart, rangeEnd] = range;
+        const t = (value - domainStart) / (domainEnd - domainStart);
+
+        return rangeStart + ((rangeEnd - rangeStart) * t);
+    };
+
+    scale.range = (values) => {
+        range = values;
+        return scale;
+    };
+
+    scale.domain = (values) => {
+        domain = values;
+        return scale;
+    };
+
+    return scale;
+});
+
+const selectMock = (node) => ({
+    text(value) {
+        if (typeof value === "undefined") {
+            return node.textContent;
+        }
+
+        node.textContent = value;
+        return this;
+    }
+});
+
+await jest.unstable_mockModule("resources/js/modules/lib/d3", () => ({
+    __esModule: true,
+    scaleLinear: scaleLinearMock,
+    select: jest.fn((node) => selectMock(node))
+}));
+
+await jest.unstable_mockModule("resources/js/modules/lib/chart/text/measure", () => ({
+    __esModule: true,
+    default: measureTextMock
+}));
+
+const { default: Text } = await import("resources/js/modules/custom/svg/text");
+
+const createConfiguration = (overrides = {}) => ({
+    numberOfInnerCircles: 2,
+    innerArcHeight: 60,
+    outerArcHeight: 150,
+    centerCircleRadius: 40,
+    circlePadding: 5,
+    textPadding: 10,
+    padDistance: 6,
+    padAngle: 0,
+    padRadius: 0,
+    colorArcWidth: 20,
+    fanDegree: 180,
+    fontScale: 100,
+    ...overrides
+});
+
+const createDatum = (overrides = {}) => ({
+    depth: 1,
+    x0: 0,
+    x1: 1,
+    data: {
+        data: {
+            name: "Jane Marie Doe",
+            firstNames: ["Jane", "Marie"],
+            lastNames: ["Doe"],
+            preferredName: "Marie",
+            alternativeName: "",
+            isAltRtl: false,
+            isNameRtl: false,
+            timespan: "",
+            marriageDateOfParents: null,
+            ...overrides.data
+        }
+    },
+    ...overrides
+});
+
+describe("Text", () => {
+    const svgStub = {
+        style: jest.fn(() => "Arial"),
+        defs: { select: jest.fn(), append: jest.fn(() => ({ append: jest.fn() })) }
+    };
+
+    beforeEach(() => {
+        measureTextMock.mockClear();
+        scaleLinearMock.mockClear();
+    });
+
+    it("splits full names into ordered label groups", () => {
+        const text = new Text(svgStub, createConfiguration());
+        const datum = createDatum();
+
+        const [firstNames, lastNames] = text.createNamesData(datum);
+
+        expect(firstNames).toEqual([
+            { label: "Jane", isPreferred: false, isLastName: false, isNameRtl: false },
+            { label: "Marie", isPreferred: true, isLastName: false, isNameRtl: false }
+        ]);
+        expect(lastNames).toEqual([
+            { label: "Doe", isPreferred: false, isLastName: true, isNameRtl: false }
+        ]);
+    });
+
+    it("truncates names based on available width and preference", () => {
+        const text = new Text(svgStub, createConfiguration());
+        const nameGroup = [
+            { label: "Anna", isPreferred: false, isLastName: false, isNameRtl: false },
+            { label: "Beatrice", isPreferred: true, isLastName: false, isNameRtl: false }
+        ];
+        const parent = {
+            style: jest.fn((property) => (property === "font-size" ? "12px" : "700"))
+        };
+
+        const truncated = text.truncateNamesData(parent, nameGroup, 100);
+
+        expect(measureTextMock).toHaveBeenCalled();
+        expect(truncated.map((name) => name.label)).toEqual(["A.", "B."]);
+        expect(parent.style).toHaveBeenCalledWith("font-size");
+        expect(parent.style).toHaveBeenCalledWith("font-weight");
+    });
+
+    it("calculates available width using arc geometry for inner labels", () => {
+        const text = new Text(svgStub, createConfiguration());
+        const datum = createDatum();
+
+        const availableWidth = text.getAvailableWidth(datum, 0);
+
+        expect(availableWidth).toBeCloseTo((Math.PI * text._geometry.relativeRadius(datum.depth, 73)) - 23);
+    });
+
+    it("calculates available width for outer arcs without geometry", () => {
+        const text = new Text(svgStub, createConfiguration());
+        const datum = createDatum({ depth: 4 });
+
+        const availableWidth = text.getAvailableWidth(datum, 0);
+
+        expect(availableWidth).toBe(150 - 20 - 5);
+    });
+
+    it("truncates date labels without trailing dots", () => {
+        const text = new Text(svgStub, createConfiguration());
+        const tspanNode = {
+            textContent: "01 JAN. 1900",
+            getComputedTextLength() {
+                return this.textContent.length * 10;
+            }
+        };
+        const parent = {
+            selectAll: () => ({
+                each: (callback) => {
+                    callback.call(tspanNode);
+                }
+            })
+        };
+
+        text.getTextLength = jest.fn(() => tspanNode.getComputedTextLength());
+
+        const truncate = text.truncateDate(parent, 50);
+        truncate.call(tspanNode);
+
+        expect(tspanNode.textContent.endsWith(".")).toBe(false);
+        expect(tspanNode.textContent.length * 10).toBeLessThanOrEqual(50);
+    });
+});


### PR DESCRIPTION
M# Sweep — Verify compliance for this milestone

## Summary
- add geometry coverage for angle calculations, radii, and arc lengths
- add text module specs for name grouping, truncation, width calculations, and date handling

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69232cfad6b08323b5a1869566924b6f)