### PR TITLE
test: extend coverage for configuration and module

### DIFF
--- a/src/Facade/DataFacade.php
+++ b/src/Facade/DataFacade.php
@@ -136,6 +136,7 @@ class DataFacade
         Individual $individual,
     ): NodeData {
         // Create a unique ID for each individual
+        /** @var int $id */
         static $id = 0;
 
         $nameProcessor  = new NameProcessor($individual);

--- a/src/Processor/ImageProcessor.php
+++ b/src/Processor/ImageProcessor.php
@@ -79,12 +79,18 @@ class ImageProcessor
                 $returnSilhouettes
                 && ($this->individual->tree()->getPreference('USE_SILHOUETTE') !== '')
             ) {
-                return $this->module->assetUrl(
+                if (method_exists($this->module, 'assetUrl') === false) {
+                    return '';
+                }
+
+                $silhouette = $this->module->assetUrl(
                     sprintf(
                         'images/silhouette-%s.svg',
                         $this->individual->sex()
                     )
                 );
+
+                return is_string($silhouette) ? $silhouette : '';
             }
         }
 

--- a/src/Processor/NameProcessor.php
+++ b/src/Processor/NameProcessor.php
@@ -207,7 +207,8 @@ class NameProcessor
         // Remove empty values and reindex array
         return array_values(
             array_filter(
-                array_merge(...$values)
+                array_merge(...$values),
+                static fn (string $value): bool => $value !== ''
             )
         );
     }

--- a/src/Traits/ModuleCustomTrait.php
+++ b/src/Traits/ModuleCustomTrait.php
@@ -59,6 +59,13 @@ trait ModuleCustomTrait
     {
         $languageFile = $this->resourcesFolder() . 'lang/' . $language . '/messages.mo';
 
-        return file_exists($languageFile) ? (new Translation($languageFile))->asArray() : [];
+        if (file_exists($languageFile) === false) {
+            return [];
+        }
+
+        /** @var array<string, string> $translations */
+        $translations = (new Translation($languageFile))->asArray();
+
+        return $translations;
     }
 }

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-fan-chart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\FanChart\Tests\Configuration;
+
+use Fig\Http\Message\RequestMethodInterface;
+use Fisharebest\Webtrees\DB;
+use GuzzleHttp\Psr7\ServerRequest;
+use MagicSunday\Webtrees\FanChart\Configuration;
+use MagicSunday\Webtrees\FanChart\Facade\DataFacade;
+use MagicSunday\Webtrees\FanChart\Module;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+#[CoversClass(Configuration::class)]
+final class ConfigurationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $locale     = \Fisharebest\Localization\Locale::create('en');
+        $translator = new \Fisharebest\Localization\Translator([], $locale->pluralRule());
+
+        $localeProperty = new ReflectionProperty(\Fisharebest\Webtrees\I18N::class, 'locale');
+        $localeProperty->setAccessible(true);
+        $localeProperty->setValue($locale);
+
+        $translatorProperty = new ReflectionProperty(\Fisharebest\Webtrees\I18N::class, 'translator');
+        $translatorProperty->setAccessible(true);
+        $translatorProperty->setValue($translator);
+    }
+
+    public function testQueriesUseDefaultsWhenMissingParameters(): void
+    {
+        $request = new ServerRequest(RequestMethodInterface::METHOD_GET, '/');
+
+        $module = $this->createModuleWithPreferences([
+            'default_generations'             => '8',
+            'default_fontScale'               => '125',
+            'default_fanDegree'               => '270',
+            'default_hideEmptySegments'       => '1',
+            'default_showColorGradients'      => '1',
+            'default_showParentMarriageDates' => '1',
+            'default_innerArcs'               => '2',
+            'default_hideSvgExport'           => '1',
+            'default_hidePngExport'           => '1',
+        ]);
+
+        $configuration = new Configuration($request, $module);
+
+        self::assertSame(8, $configuration->getGenerations());
+        self::assertSame(125, $configuration->getFontScale());
+        self::assertSame(270, $configuration->getFanDegree());
+        self::assertTrue($configuration->getHideEmptySegments());
+        self::assertTrue($configuration->getShowColorGradients());
+        self::assertTrue($configuration->getShowParentMarriageDates());
+        self::assertSame(2, $configuration->getInnerArcs());
+        self::assertTrue($configuration->getHideSvgExport());
+        self::assertTrue($configuration->getHidePngExport());
+    }
+
+    public function testPostRequestsAreValidatedAgainstRanges(): void
+    {
+        $request = new ServerRequest(
+            RequestMethodInterface::METHOD_POST,
+            '/',
+            [],
+            null,
+            '1.1'
+        );
+
+        $request = $request->withParsedBody([
+            'generations'             => '4',
+            'fontScale'               => '140',
+            'fanDegree'               => '300',
+            'hideEmptySegments'       => '1',
+            'showColorGradients'      => '1',
+            'showParentMarriageDates' => '1',
+            'innerArcs'               => '1',
+            'hideSvgExport'           => '0',
+            'hidePngExport'           => '1',
+        ]);
+
+        $module = $this->createModuleWithPreferences([
+            'default_generations'             => '6',
+            'default_fontScale'               => '100',
+            'default_fanDegree'               => '210',
+            'default_hideEmptySegments'       => '0',
+            'default_showColorGradients'      => '0',
+            'default_showParentMarriageDates' => '0',
+            'default_innerArcs'               => '3',
+            'default_hideSvgExport'           => '0',
+            'default_hidePngExport'           => '0',
+        ]);
+
+        $configuration = new Configuration($request, $module);
+
+        self::assertSame(4, $configuration->getGenerations());
+        self::assertSame(140, $configuration->getFontScale());
+        self::assertSame(300, $configuration->getFanDegree());
+        self::assertTrue($configuration->getHideEmptySegments());
+        self::assertTrue($configuration->getShowColorGradients());
+        self::assertTrue($configuration->getShowParentMarriageDates());
+        self::assertSame(1, $configuration->getInnerArcs());
+        self::assertFalse($configuration->getHideSvgExport());
+        self::assertTrue($configuration->getHidePngExport());
+    }
+
+    public function testSelectableListsReflectDefinedRanges(): void
+    {
+        $request = new ServerRequest(RequestMethodInterface::METHOD_GET, '/');
+
+        $module = $this->createModuleWithPreferences([
+            'default_generations' => '6',
+            'default_fontScale'   => '100',
+            'default_fanDegree'   => '210',
+            'default_innerArcs'   => '3',
+        ]);
+
+        $configuration = new Configuration($request, $module);
+
+        self::assertCount(9, $configuration->getGenerationsList());
+        self::assertSame('2', $configuration->getGenerationsList()[2]);
+        self::assertSame('10', $configuration->getGenerationsList()[10]);
+        self::assertCount(6, $configuration->getInnerArcsList());
+        self::assertSame('0', $configuration->getInnerArcsList()[0]);
+        self::assertSame('5', $configuration->getInnerArcsList()[5]);
+    }
+
+    /**
+     * @param array<string, string> $preferences
+     */
+    private function createModuleWithPreferences(array $preferences): Module
+    {
+        static $initialised = false;
+
+        if ($initialised === false) {
+            $database = new DB();
+            $database->addConnection([
+                'driver'   => 'sqlite',
+                'database' => ':memory:',
+            ]);
+            $database->setAsGlobal();
+            $database->bootEloquent();
+            DB::connection()->getSchemaBuilder()->create('module_setting', static function (\Illuminate\Database\Schema\Blueprint $table): void {
+                $table->string('module_name');
+                $table->string('setting_name');
+                $table->string('setting_value');
+            });
+
+            $initialised = true;
+        }
+
+        DB::table('module_setting')->delete();
+        DB::table('module_setting')->insert(
+            array_map(
+                static fn (string $name, string $value): array => [
+                    'module_name'   => 'webtrees-fan-chart',
+                    'setting_name'  => $name,
+                    'setting_value' => $value,
+                ],
+                array_keys($preferences),
+                $preferences
+            )
+        );
+
+        $chartService = $this->createMock(\Fisharebest\Webtrees\Services\ChartService::class);
+        $module       = new Module($chartService, new DataFacade());
+
+        $reflection = new ReflectionProperty(\Fisharebest\Webtrees\Module\AbstractModule::class, 'name');
+        $reflection->setAccessible(true);
+        $reflection->setValue($module, 'webtrees-fan-chart');
+
+        return $module;
+    }
+}

--- a/tests/Facade/DataFacadeTest.php
+++ b/tests/Facade/DataFacadeTest.php
@@ -1,0 +1,228 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-fan-chart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\FanChart\Tests\Facade;
+
+use Fisharebest\Webtrees\Contracts\ContainerInterface;
+use Fisharebest\Webtrees\Contracts\RouteFactoryInterface;
+use Fisharebest\Webtrees\Date;
+use Fisharebest\Webtrees\Family;
+use Fisharebest\Webtrees\I18N;
+use Fisharebest\Webtrees\Individual;
+use Fisharebest\Webtrees\Module\ModuleCustomInterface;
+use Fisharebest\Webtrees\Tree;
+use Fisharebest\Webtrees\Validator;
+use GuzzleHttp\Psr7\ServerRequest;
+use Illuminate\Support\Collection;
+use MagicSunday\Webtrees\FanChart\Configuration;
+use MagicSunday\Webtrees\FanChart\Facade\DataFacade;
+use MagicSunday\Webtrees\FanChart\Model\Node;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+use function array_map;
+
+#[CoversClass(DataFacade::class)]
+final class DataFacadeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Validator::serverParams(new ServerRequest('GET', '/'));
+        \Fisharebest\Webtrees\Registry::calendarDateFactory(new \Fisharebest\Webtrees\Factories\CalendarDateFactory());
+
+        $locale     = \Fisharebest\Localization\Locale::create('en');
+        $translator = new \Fisharebest\Localization\Translator([], $locale->pluralRule());
+
+        $localeProperty = new ReflectionProperty(I18N::class, 'locale');
+        $localeProperty->setAccessible(true);
+        $localeProperty->setValue($locale);
+
+        $translatorProperty = new ReflectionProperty(I18N::class, 'translator');
+        $translatorProperty->setAccessible(true);
+        $translatorProperty->setValue($translator);
+    }
+
+    public function testTreeStructureIncludesParentsUntilConfiguredLimit(): void
+    {
+        $routeFactory = new class implements RouteFactoryInterface {
+            public function route(string $route_name, array $parameters = []): string
+            {
+                return '/route/' . $route_name . '?' . http_build_query($parameters);
+            }
+
+            public function routeMap(): \Aura\Router\Map
+            {
+                return new \Aura\Router\Map(new \Aura\Router\Route());
+            }
+        };
+
+        $container = new class($routeFactory) implements ContainerInterface {
+            public function __construct(private readonly RouteFactoryInterface $routeFactory)
+            {
+            }
+
+            public function get(string $id): mixed
+            {
+                return $this->routeFactory;
+            }
+
+            public function has(string $id): bool
+            {
+                return $id === RouteFactoryInterface::class;
+            }
+
+            public function set(string $id, object $object): static
+            {
+                return $this;
+            }
+        };
+
+        \Fisharebest\Webtrees\Registry::routeFactory($routeFactory);
+        \Fisharebest\Webtrees\Registry::container($container);
+
+        $configuration = $this->createMock(Configuration::class);
+        $configuration->method('getGenerations')->willReturn(2);
+
+        $module = $this->createMock(ModuleCustomInterface::class);
+        $module->method('name')->willReturn('webtrees-fan-chart');
+
+        $childFamily  = $this->createMock(Family::class);
+        $spouseFamily = $this->createMock(Family::class);
+
+        $tree = $this->createMock(Tree::class);
+        $tree->method('name')->willReturn('main');
+        $tree->method('getPreference')->willReturn('1');
+
+        $root = $this->createMock(Individual::class);
+        $root->method('xref')->willReturn('I1');
+        $root->method('url')->willReturn('/individual/I1');
+        $root->method('sex')->willReturn('M');
+        $root->method('fullName')->willReturn('Root Individual');
+        $root->method('canShow')->willReturn(true);
+        $root->method('canShowName')->willReturn(true);
+        $root->method('getAllNames')->willReturn($this->buildNameSet('Root', 'Individual'));
+        $root->method('getPrimaryName')->willReturn(0);
+        $root->method('getSecondaryName')->willReturn(0);
+        $root->method('getBirthDate')->willReturn($this->createDate('1 JAN 1900'));
+        $root->method('getDeathDate')->willReturn($this->createDate('1 JAN 1980'));
+        $root->method('tree')->willReturn($tree);
+        $root->method('spouseFamilies')->willReturn(new Collection([$spouseFamily]));
+        $root->method('childFamilies')->willReturn(new Collection([$childFamily]));
+        $root->method('findHighlightedMediaFile')->willReturn(null);
+
+        $father = $this->createMock(Individual::class);
+        $father->method('xref')->willReturn('I2');
+        $father->method('url')->willReturn('/individual/I2');
+        $father->method('sex')->willReturn('M');
+        $father->method('fullName')->willReturn('Father Individual');
+        $father->method('canShow')->willReturn(true);
+        $father->method('canShowName')->willReturn(true);
+        $father->method('getAllNames')->willReturn($this->buildNameSet('Father', 'Individual'));
+        $father->method('getPrimaryName')->willReturn(0);
+        $father->method('getSecondaryName')->willReturn(0);
+        $father->method('getBirthDate')->willReturn($this->createDate('1 JAN 1870'));
+        $father->method('getDeathDate')->willReturn($this->createDate('1 JAN 1940'));
+        $father->method('tree')->willReturn($tree);
+        $father->method('spouseFamilies')->willReturn(new Collection([$spouseFamily]));
+        $father->method('childFamilies')->willReturn(new Collection());
+        $father->method('findHighlightedMediaFile')->willReturn(null);
+
+        $mother = $this->createMock(Individual::class);
+        $mother->method('xref')->willReturn('I3');
+        $mother->method('url')->willReturn('/individual/I3');
+        $mother->method('sex')->willReturn('F');
+        $mother->method('fullName')->willReturn('Mother Individual');
+        $mother->method('canShow')->willReturn(true);
+        $mother->method('canShowName')->willReturn(true);
+        $mother->method('getAllNames')->willReturn($this->buildNameSet('Mother', 'Individual'));
+        $mother->method('getPrimaryName')->willReturn(0);
+        $mother->method('getSecondaryName')->willReturn(0);
+        $mother->method('getBirthDate')->willReturn($this->createDate('1 JAN 1875'));
+        $mother->method('getDeathDate')->willReturn($this->createDate('1 JAN 1950'));
+        $mother->method('tree')->willReturn($tree);
+        $mother->method('spouseFamilies')->willReturn(new Collection([$spouseFamily]));
+        $mother->method('childFamilies')->willReturn(new Collection());
+        $mother->method('findHighlightedMediaFile')->willReturn(null);
+
+        $spouseFamily->method('husband')->willReturn($father);
+        $spouseFamily->method('wife')->willReturn($mother);
+        $spouseFamily->method('getMarriageDate')->willReturn($this->createDate('1 JAN 1890'));
+
+        $childFamily->method('husband')->willReturn($father);
+        $childFamily->method('wife')->willReturn($mother);
+        $childFamily->method('getMarriageDate')->willReturn($this->createDate('1 JAN 1890'));
+
+        $facade   = new DataFacade();
+        $rootNode = $facade
+            ->setModule($module)
+            ->setConfiguration($configuration)
+            ->createTreeStructure($root);
+
+        self::assertInstanceOf(Node::class, $rootNode);
+
+        $data           = $rootNode->getData();
+        $serializedData = $data->jsonSerialize();
+        self::assertSame('I1', $serializedData['xref']);
+        self::assertSame('/route/module?module=webtrees-fan-chart&action=update&xref=I1&tree=main&generations=2', $serializedData['updateUrl']);
+
+        $serialized = $rootNode->jsonSerialize();
+
+        self::assertArrayHasKey('parents', $serialized);
+        /** @var array<int, Node> $parents */
+        $parents = $serialized['parents'];
+
+        self::assertCount(2, $parents);
+        $parentIds = array_map(static fn (Node $node): int => $node->getData()->getId(), $parents);
+        self::assertSame([2, 3], $parentIds);
+    }
+
+    /**
+     * @return array<int, array<string, string|bool|array<string>>>
+     */
+    private function buildNameSet(string $firstName, string $lastName): array
+    {
+        return [
+            [
+                'type'                    => 'NAME',
+                'fullNN'                  => $firstName . ' <span class="NAME"><span class="SURN">' . $lastName . '</span></span>',
+                'full'                    => $firstName . ' <span class="NAME"><span class="SURN">' . $lastName . '</span></span>',
+                'sort'                    => $lastName . ', ' . $firstName,
+                'list'                    => $firstName . ' ' . $lastName,
+                'surname'                 => $lastName,
+                'addname'                 => '',
+                'prefix'                  => '',
+                'surn'                    => $lastName,
+                'givn'                    => $firstName,
+                'initials'                => $firstName[0] . ' ' . $lastName[0],
+                'spfx'                    => '',
+                'nsfx'                    => '',
+                'nickname'                => '',
+                'display_as'              => 'default',
+                'type_label'              => 'Name',
+                'surname_prefix'          => '',
+                'show'                    => true,
+                'script'                  => 'Latn',
+                'parts'                   => [],
+                'prim'                    => 'Y',
+                'type_id'                 => '0',
+                'fullNNalternativeRender' => $firstName . ' <span class="SURN">' . $lastName . '</span>',
+            ],
+        ];
+    }
+
+    private function createDate(string $display): Date
+    {
+        return new Date($display);
+    }
+}

--- a/tests/Model/NodeDataTest.php
+++ b/tests/Model/NodeDataTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-fan-chart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\FanChart\Tests\Model;
+
+use MagicSunday\Webtrees\FanChart\Model\NodeData;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(NodeData::class)]
+final class NodeDataTest extends TestCase
+{
+    public function testJsonSerializeContainsAllConfiguredFields(): void
+    {
+        $nodeData = (new NodeData())
+            ->setId(42)
+            ->setXref('I1')
+            ->setUrl('/tree/example/I1')
+            ->setUpdateUrl('/tree/example/I1/update')
+            ->setGeneration(3)
+            ->setName('Example Person')
+            ->setIsNameRtl(false)
+            ->setFirstNames(['Example', 'Person'])
+            ->setLastNames(['Family'])
+            ->setPreferredName('Example')
+            ->setAlternativeName('Alias')
+            ->setIsAltRtl(true)
+            ->setThumbnail('/path/to/image.png')
+            ->setSex('M')
+            ->setBirth('1 JAN 1900')
+            ->setDeath('31 DEC 1950')
+            ->setMarriageDate('1 JAN 1930')
+            ->setMarriageDateOfParents('1 JAN 1880')
+            ->setTimespan('1900-1950');
+
+        $result = $nodeData->jsonSerialize();
+
+        self::assertSame(42, $result['id']);
+        self::assertSame('I1', $result['xref']);
+        self::assertSame('/tree/example/I1', $result['url']);
+        self::assertSame('/tree/example/I1/update', $result['updateUrl']);
+        self::assertSame(3, $result['generation']);
+        self::assertSame('Example Person', $result['name']);
+        self::assertFalse($result['isNameRtl']);
+        self::assertSame(['Example', 'Person'], $result['firstNames']);
+        self::assertSame(['Family'], $result['lastNames']);
+        self::assertSame('Example', $result['preferredName']);
+        self::assertSame('Alias', $result['alternativeName']);
+        self::assertTrue($result['isAltRtl']);
+        self::assertSame('/path/to/image.png', $result['thumbnail']);
+        self::assertSame('M', $result['sex']);
+        self::assertSame('1 JAN 1900', $result['birth']);
+        self::assertSame('31 DEC 1950', $result['death']);
+        self::assertSame('1 JAN 1930', $result['marriageDate']);
+        self::assertSame('1 JAN 1880', $result['marriageDateOfParents']);
+        self::assertSame('1900-1950', $result['timespan']);
+    }
+}

--- a/tests/Model/NodeTest.php
+++ b/tests/Model/NodeTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-fan-chart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\FanChart\Tests\Model;
+
+use MagicSunday\Webtrees\FanChart\Model\Node;
+use MagicSunday\Webtrees\FanChart\Model\NodeData;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Node::class)]
+final class NodeTest extends TestCase
+{
+    public function testJsonSerializeAddsParentsWhenPresent(): void
+    {
+        $childData  = (new NodeData())->setId(1);
+        $fatherData = (new NodeData())->setId(2);
+
+        $child  = new Node($childData);
+        $father = new Node($fatherData);
+
+        $child->addParent($father);
+
+        $result = $child->jsonSerialize();
+
+        self::assertSame($childData, $result['data']);
+        self::assertArrayHasKey('parents', $result);
+        self::assertSame([$father], $result['parents']);
+    }
+
+    public function testJsonSerializeOmitsParentsWhenEmpty(): void
+    {
+        $child = new Node(new NodeData());
+
+        $result = $child->jsonSerialize();
+
+        self::assertSame(['data' => $child->getData()], $result);
+    }
+}

--- a/tests/Module/ModuleTest.php
+++ b/tests/Module/ModuleTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-fan-chart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\FanChart\Tests\Module;
+
+use Fisharebest\Webtrees\Contracts\ContainerInterface;
+use Fisharebest\Webtrees\Contracts\RouteFactoryInterface;
+use Fisharebest\Webtrees\I18N;
+use Fisharebest\Webtrees\Individual;
+use Fisharebest\Webtrees\Tree;
+use MagicSunday\Webtrees\FanChart\Facade\DataFacade;
+use MagicSunday\Webtrees\FanChart\Module;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+#[CoversClass(Module::class)]
+final class ModuleTest extends TestCase
+{
+    public function testTraitHelpersExposeExpectedValues(): void
+    {
+        $routeFactory = new class implements RouteFactoryInterface {
+            public function route(string $route_name, array $parameters = []): string
+            {
+                return '/route/' . $route_name . '?' . http_build_query($parameters);
+            }
+
+            public function routeMap(): \Aura\Router\Map
+            {
+                return new \Aura\Router\Map(new \Aura\Router\Route());
+            }
+        };
+
+        $container = new class($routeFactory) implements ContainerInterface {
+            public function __construct(private readonly RouteFactoryInterface $routeFactory)
+            {
+            }
+
+            public function get(string $id): mixed
+            {
+                return $this->routeFactory;
+            }
+
+            public function has(string $id): bool
+            {
+                return $id === RouteFactoryInterface::class;
+            }
+
+            public function set(string $id, object $object): static
+            {
+                return $this;
+            }
+        };
+
+        \Fisharebest\Webtrees\Registry::routeFactory($routeFactory);
+        \Fisharebest\Webtrees\Registry::container($container);
+
+        $chartService = $this->createMock(\Fisharebest\Webtrees\Services\ChartService::class);
+        $module       = new Module($chartService, new DataFacade());
+        $individual   = $this->createMock(Individual::class);
+        $tree         = $this->createMock(Tree::class);
+
+        $locale     = \Fisharebest\Localization\Locale::create('en');
+        $translator = new \Fisharebest\Localization\Translator([], $locale->pluralRule());
+
+        $localeProperty = new ReflectionProperty(I18N::class, 'locale');
+        $localeProperty->setAccessible(true);
+        $localeProperty->setValue($locale);
+
+        $translatorProperty = new ReflectionProperty(I18N::class, 'translator');
+        $translatorProperty->setAccessible(true);
+        $translatorProperty->setValue($translator);
+
+        $individual->method('fullName')->willReturn('Example Person');
+        $individual->method('xref')->willReturn('I1');
+        $individual->method('tree')->willReturn($tree);
+        $tree->method('name')->willReturn('main');
+
+        self::assertSame('menu-chart-fanchart', $module->chartMenuClass());
+        self::assertStringContainsString('Example Person', $module->chartTitle($individual));
+        self::assertStringContainsString('/route/webtrees-fan-chart?', $module->chartUrl($individual));
+        self::assertSame(Module::CUSTOM_AUTHOR, $module->customModuleAuthorName());
+        self::assertSame(Module::CUSTOM_VERSION, $module->customModuleVersion());
+        self::assertSame(Module::CUSTOM_SUPPORT_URL, $module->customModuleSupportUrl());
+        self::assertSame(Module::CUSTOM_LATEST_VERSION, $module->customModuleLatestVersionUrl());
+        self::assertSame([], $module->customTranslations('zz'));
+    }
+}

--- a/tests/Module/VersionInformationTest.php
+++ b/tests/Module/VersionInformationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-fan-chart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\FanChart\Tests\Module;
+
+use Fisharebest\Webtrees\Contracts\CacheFactoryInterface;
+use Fisharebest\Webtrees\Module\ModuleCustomInterface;
+use MagicSunday\Webtrees\FanChart\Module\VersionInformation;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+#[CoversClass(VersionInformation::class)]
+final class VersionInformationTest extends TestCase
+{
+    public function testFetchLatestVersionFallsBackToCustomWhenUrlMissing(): void
+    {
+        $factory = new class implements CacheFactoryInterface {
+            public function array(): \Fisharebest\Webtrees\Cache
+            {
+                return new \Fisharebest\Webtrees\Cache(new ArrayAdapter());
+            }
+
+            public function file(): \Fisharebest\Webtrees\Cache
+            {
+                return new \Fisharebest\Webtrees\Cache(new ArrayAdapter());
+            }
+        };
+
+        \Fisharebest\Webtrees\Registry::cache($factory);
+
+        $module = $this->createMock(ModuleCustomInterface::class);
+        $module->method('customModuleLatestVersionUrl')->willReturn('');
+        $module->method('customModuleVersion')->willReturn('3.0.1');
+        $module->method('name')->willReturn('webtrees-fan-chart');
+
+        $versionInformation = new VersionInformation($module);
+
+        self::assertSame('3.0.1', $versionInformation->fetchLatestVersion());
+    }
+}

--- a/tests/Processor/DateProcessorTest.php
+++ b/tests/Processor/DateProcessorTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-fan-chart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\FanChart\Tests\Processor;
+
+use Fisharebest\Webtrees\Date;
+use Fisharebest\Webtrees\Family;
+use Fisharebest\Webtrees\Individual;
+use Illuminate\Support\Collection;
+use MagicSunday\Webtrees\FanChart\Processor\DateProcessor;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DateProcessor::class)]
+final class DateProcessorTest extends TestCase
+{
+    public function testLifetimeDescriptionPrefersBothBirthAndDeathYears(): void
+    {
+        $individual = $this->createConfiguredIndividual();
+        $processor  = new DateProcessor($individual);
+
+        self::assertSame('1900-1950', $processor->getLifetimeDescription());
+    }
+
+    public function testMarriageDatesDecodeHtml(): void
+    {
+        $individual = $this->createConfiguredIndividual();
+        $processor  = new DateProcessor($individual);
+
+        self::assertSame('1 JAN 1930', $processor->getMarriageDate());
+        self::assertSame('1 JAN 1880', $processor->getMarriageDateOfParents());
+    }
+
+    private function createConfiguredIndividual(
+        bool $isDead = true,
+        bool $withBirth = true,
+        bool $withDeath = true,
+    ): Individual {
+        $birthDate = $this->createDate(1900, '<span>1 JAN 1900</span>', $withBirth);
+        $deathDate = $this->createDate(1950, '<span>31 DEC 1950</span>', $withDeath);
+
+        $marriageDate   = $this->createDate(1930, '<span>1 JAN 1930</span>', true);
+        $parentMarriage = $this->createDate(1880, '<span>1 JAN 1880</span>', true);
+        $spouseFamily   = $this->createConfiguredFamily($marriageDate);
+        $parentFamily   = $this->createConfiguredFamily($parentMarriage);
+
+        $individual = $this->createMock(Individual::class);
+        $individual->method('getBirthDate')->willReturn($birthDate);
+        $individual->method('getDeathDate')->willReturn($deathDate);
+        $individual->method('isDead')->willReturn($isDead);
+        $individual->method('spouseFamilies')->willReturn($this->createCollection($spouseFamily));
+        $individual->method('childFamilies')->willReturn($this->createCollection($parentFamily));
+
+        return $individual;
+    }
+
+    private function createDate(int $year, string $display, bool $ok): Date
+    {
+        $minimumDate = $this->createMock(Date\AbstractCalendarDate::class);
+        $minimumDate->method('year')->willReturn($year);
+
+        $date = $this->createMock(Date::class);
+        $date->method('minimumDate')->willReturn($minimumDate);
+        $date->method('display')->willReturn($display);
+        $date->method('isOK')->willReturn($ok);
+
+        return $date;
+    }
+
+    /**
+     * @return Collection<int, Family>
+     */
+    private function createCollection(?Family $family): Collection
+    {
+        return new Collection($family !== null ? [$family] : []);
+    }
+
+    private function createConfiguredFamily(Date $marriageDate): Family
+    {
+        $family = $this->createMock(Family::class);
+        $family->method('getMarriageDate')->willReturn($marriageDate);
+
+        return $family;
+    }
+}

--- a/tests/Processor/ImageProcessorTest.php
+++ b/tests/Processor/ImageProcessorTest.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-fan-chart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\FanChart\Tests\Processor;
+
+use Fisharebest\Webtrees\Individual;
+use Fisharebest\Webtrees\MediaFile;
+use Fisharebest\Webtrees\Module\ModuleCustomInterface;
+use Fisharebest\Webtrees\Tree;
+use MagicSunday\Webtrees\FanChart\Processor\ImageProcessor;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ImageProcessor::class)]
+final class ImageProcessorTest extends TestCase
+{
+    public function testReturnsHighlightImageWhenAvailable(): void
+    {
+        $mediaFile = $this->createMock(MediaFile::class);
+        $mediaFile->method('imageUrl')->with(100, 100, 'contain')->willReturn('/highlight.png');
+
+        $tree = $this->createConfiguredTree('1', '1');
+
+        $individual = $this->createMock(Individual::class);
+        $individual->method('canShow')->willReturn(true);
+        $individual->method('tree')->willReturn($tree);
+        $individual->method('findHighlightedMediaFile')->willReturn($mediaFile);
+
+        $module    = $this->createModuleStub('/highlight.png');
+        $processor = new ImageProcessor($module, $individual);
+
+        self::assertSame('/highlight.png', $processor->getHighlightImageUrl(100, 100));
+    }
+
+    public function testReturnsSilhouetteWhenEnabledAndNoMediaFound(): void
+    {
+        $tree = $this->createConfiguredTree('1', '1');
+
+        $individual = $this->createMock(Individual::class);
+        $individual->method('canShow')->willReturn(true);
+        $individual->method('tree')->willReturn($tree);
+        $individual->method('findHighlightedMediaFile')->willReturn(null);
+        $individual->method('sex')->willReturn('M');
+
+        $module = $this->createModuleStub('/silhouette.svg');
+
+        $processor = new ImageProcessor($module, $individual);
+
+        self::assertSame('/silhouette.svg', $processor->getHighlightImageUrl(100, 100));
+    }
+
+    public function testReturnsEmptyStringWhenImageNotAllowed(): void
+    {
+        $tree = $this->createConfiguredTree('', '');
+
+        $individual = $this->createMock(Individual::class);
+        $individual->method('canShow')->willReturn(false);
+        $individual->method('tree')->willReturn($tree);
+
+        $module    = $this->createModuleStub('');
+        $processor = new ImageProcessor($module, $individual);
+
+        self::assertSame('', $processor->getHighlightImageUrl());
+    }
+
+    private function createConfiguredTree(string $highlightPreference, string $silhouettePreference): Tree
+    {
+        $tree = $this->createMock(Tree::class);
+        $tree->method('getPreference')->willReturnCallback(
+            static function (string $name) use ($highlightPreference, $silhouettePreference): string {
+                return $name === 'SHOW_HIGHLIGHT_IMAGES' ? $highlightPreference : $silhouettePreference;
+            }
+        );
+
+        return $tree;
+    }
+
+    private function createModuleStub(string $assetUrl): ModuleCustomInterface
+    {
+        return new class($assetUrl) implements ModuleCustomInterface {
+            public function __construct(private readonly string $asset)
+            {
+            }
+
+            public function assetUrl(string $asset): string
+            {
+                return $this->asset;
+            }
+
+            public function customModuleAuthorName(): string
+            {
+                return 'test';
+            }
+
+            public function customModuleVersion(): string
+            {
+                return '0.0.0';
+            }
+
+            public function customModuleLatestVersionUrl(): string
+            {
+                return '';
+            }
+
+            public function customModuleLatestVersion(): string
+            {
+                return '0.0.0';
+            }
+
+            public function customModuleSupportUrl(): string
+            {
+                return '';
+            }
+
+            public function customTranslations(string $language): array
+            {
+                return [];
+            }
+
+            public function boot(): void
+            {
+            }
+
+            public function setName(string $name): void
+            {
+            }
+
+            public function name(): string
+            {
+                return 'test';
+            }
+
+            public function setEnabled(bool $enabled): self
+            {
+                return $this;
+            }
+
+            public function isEnabled(): bool
+            {
+                return true;
+            }
+
+            public function isEnabledByDefault(): bool
+            {
+                return true;
+            }
+
+            public function title(): string
+            {
+                return 'test';
+            }
+
+            public function description(): string
+            {
+                return 'test';
+            }
+
+            public function accessLevel(Tree $tree, string $interface): int
+            {
+                return 0;
+            }
+
+            public function getPreference(string $setting_name, string $default = ''): string
+            {
+                return $default;
+            }
+
+            public function setPreference(string $setting_name, string $setting_value): void
+            {
+            }
+
+            public function resourcesFolder(): string
+            {
+                return '/tmp';
+            }
+        };
+    }
+}

--- a/tests/Processor/NameProcessorTest.php
+++ b/tests/Processor/NameProcessorTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-fan-chart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\FanChart\Tests\Processor;
+
+use Fisharebest\Webtrees\Individual;
+use MagicSunday\Webtrees\FanChart\Processor\NameProcessor;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(NameProcessor::class)]
+final class NameProcessorTest extends TestCase
+{
+    public function testNameExtractionProvidesFirstLastAndPreferredParts(): void
+    {
+        $names = [
+            [
+                'type'                    => 'NAME',
+                'fullNN'                  => 'John <span class="NAME"><span class="SURN">Doe</span></span>',
+                'full'                    => 'John <span class="NAME"><span class="SURN">Doe</span></span>',
+                'sort'                    => 'Doe, John',
+                'list'                    => 'John Doe',
+                'surname'                 => 'Doe',
+                'addname'                 => '',
+                'prefix'                  => '',
+                'surn'                    => 'Doe',
+                'givn'                    => 'John',
+                'initials'                => 'J D',
+                'spfx'                    => '',
+                'nsfx'                    => '',
+                'nickname'                => '',
+                'display_as'              => 'default',
+                'type_label'              => 'Name',
+                'surname_prefix'          => '',
+                'show'                    => true,
+                'script'                  => 'Latn',
+                'parts'                   => [],
+                'prim'                    => 'Y',
+                'type_id'                 => 0,
+                'fullNNalternativeRender' => 'John <span class="SURN">Doe</span>',
+            ],
+        ];
+
+        $individual = $this->createMock(Individual::class);
+        $individual->method('getAllNames')->willReturn($names);
+        $individual->method('getPrimaryName')->willReturn(0);
+        $individual->method('getSecondaryName')->willReturn(0);
+        $individual->method('canShowName')->willReturn(true);
+
+        $processor = new NameProcessor($individual);
+
+        self::assertSame('John <span class="NAME"><span class="SURN">Doe</span></span>', $processor->getFullName());
+        self::assertSame(['John'], $processor->getFirstNames());
+        self::assertSame(['Doe'], $processor->getLastNames());
+        self::assertSame('', $processor->getPreferredName());
+        self::assertSame('', $processor->getAlternateName($individual));
+    }
+
+    public function testAlternateNameReturnsSecondaryNameWhenDifferent(): void
+    {
+        $names = [
+            [
+                'type'                    => 'NAME',
+                'fullNN'                  => 'John <span class="NAME"><span class="SURN">Doe</span></span>',
+                'full'                    => 'John <span class="NAME"><span class="SURN">Doe</span></span>',
+                'sort'                    => 'Doe, John',
+                'list'                    => 'John Doe',
+                'surname'                 => 'Doe',
+                'addname'                 => '',
+                'prefix'                  => '',
+                'surn'                    => 'Doe',
+                'givn'                    => 'John',
+                'initials'                => 'J D',
+                'spfx'                    => '',
+                'nsfx'                    => '',
+                'nickname'                => '',
+                'display_as'              => 'default',
+                'type_label'              => 'Name',
+                'surname_prefix'          => '',
+                'show'                    => true,
+                'script'                  => 'Latn',
+                'parts'                   => [],
+                'prim'                    => 'Y',
+                'type_id'                 => 0,
+                'fullNNalternativeRender' => 'John <span class="SURN">Doe</span>',
+            ],
+            [
+                'type'                    => 'NAME',
+                'fullNN'                  => 'Johnny <span class="NAME"><span class="SURN">Doe</span></span>',
+                'full'                    => 'Johnny <span class="NAME"><span class="SURN">Doe</span></span>',
+                'sort'                    => 'Doe, Johnny',
+                'list'                    => 'Johnny Doe',
+                'surname'                 => 'Doe',
+                'addname'                 => '',
+                'prefix'                  => '',
+                'surn'                    => 'Doe',
+                'givn'                    => 'Johnny',
+                'initials'                => 'J D',
+                'spfx'                    => '',
+                'nsfx'                    => '',
+                'nickname'                => '',
+                'display_as'              => 'default',
+                'type_label'              => 'Name',
+                'surname_prefix'          => '',
+                'show'                    => true,
+                'script'                  => 'Latn',
+                'parts'                   => [],
+                'prim'                    => 'N',
+                'type_id'                 => 0,
+                'fullNNalternativeRender' => 'Johnny <span class="SURN">Doe</span>',
+            ],
+        ];
+
+        $individual = $this->createMock(Individual::class);
+        $individual->method('getAllNames')->willReturn($names);
+        $individual->method('getPrimaryName')->willReturn(0);
+        $individual->method('getSecondaryName')->willReturn(1);
+        $individual->method('canShowName')->willReturn(true);
+
+        $processor = new NameProcessor($individual);
+
+        self::assertSame('Johnny <span class="NAME"><span class="SURN">Doe</span></span>', $processor->getAlternateName($individual));
+    }
+}


### PR DESCRIPTION
M# Sweep — Verify compliance for this milestone

## Summary
- add configuration coverage to exercise GET/POST defaults, range validation, and list helpers
- add facade, module, and version information tests to verify routing, caching, and translated outputs
- tighten processor typing for silhouettes, name parsing, and module translations to satisfy static analysis

## Testing
- composer ci:test:php:unit
- composer ci:test:php:phpstan
- composer ci:cgl

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923373f5dc48323b4a9ecd2684cc1e6)