### PR TITLE
Add PHPUnit attributes to test suite

### DIFF
--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -24,12 +24,19 @@ use MagicSunday\Webtrees\FanChart\Configuration;
 use MagicSunday\Webtrees\FanChart\Facade\DataFacade;
 use MagicSunday\Webtrees\FanChart\Module;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
 #[CoversClass(Configuration::class)]
+/**
+ * Verifies that configuration handling honors defaults, validation, and selectable ranges.
+ */
 final class ConfigurationTest extends TestCase
 {
+    /**
+     * Ensures locale and translator are initialised before each test.
+     */
     protected function setUp(): void
     {
         parent::setUp();
@@ -44,7 +51,11 @@ final class ConfigurationTest extends TestCase
         $translatorProperty->setValue($translator);
     }
 
-    public function testQueriesUseDefaultsWhenMissingParameters(): void
+    /**
+     * Ensures GET requests fall back to configured defaults when parameters are absent.
+     */
+    #[Test]
+    public function queriesUseDefaultsWhenMissingParameters(): void
     {
         $request = new ServerRequest(RequestMethodInterface::METHOD_GET, '/');
 
@@ -73,7 +84,11 @@ final class ConfigurationTest extends TestCase
         self::assertTrue($configuration->getHidePngExport());
     }
 
-    public function testPostRequestsAreValidatedAgainstRanges(): void
+    /**
+     * Ensures POSTed values are validated against allowed ranges and sanitised.
+     */
+    #[Test]
+    public function postRequestsAreValidatedAgainstRanges(): void
     {
         $request = new ServerRequest(
             RequestMethodInterface::METHOD_POST,
@@ -120,7 +135,11 @@ final class ConfigurationTest extends TestCase
         self::assertTrue($configuration->getHidePngExport());
     }
 
-    public function testSelectableListsReflectDefinedRanges(): void
+    /**
+     * Confirms list getters expose complete ranges derived from default configuration.
+     */
+    #[Test]
+    public function selectableListsReflectDefinedRanges(): void
     {
         $request = new ServerRequest(RequestMethodInterface::METHOD_GET, '/');
 
@@ -142,6 +161,8 @@ final class ConfigurationTest extends TestCase
     }
 
     /**
+     * Creates a module instance prepopulated with the provided preferences.
+     *
      * @param array<string, string> $preferences
      */
     private function createModuleWithPreferences(array $preferences): Module

--- a/tests/Facade/DataFacadeTest.php
+++ b/tests/Facade/DataFacadeTest.php
@@ -32,14 +32,21 @@ use MagicSunday\Webtrees\FanChart\Configuration;
 use MagicSunday\Webtrees\FanChart\Facade\DataFacade;
 use MagicSunday\Webtrees\FanChart\Model\Node;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
 use function array_map;
 
 #[CoversClass(DataFacade::class)]
+/**
+ * Validates tree construction and data extraction performed by the facade.
+ */
 final class DataFacadeTest extends TestCase
 {
+    /**
+     * Prepares router and translation context required by the facade.
+     */
     protected function setUp(): void
     {
         parent::setUp();
@@ -57,7 +64,11 @@ final class DataFacadeTest extends TestCase
         $translatorProperty->setValue($translator);
     }
 
-    public function testTreeStructureIncludesParentsUntilConfiguredLimit(): void
+    /**
+     * Ensures the facade builds a node hierarchy respecting generation limits and URLs.
+     */
+    #[Test]
+    public function treeStructureIncludesParentsUntilConfiguredLimit(): void
     {
         $routeFactory = new class implements RouteFactoryInterface {
             public function route(string $route_name, array $parameters = []): string
@@ -192,6 +203,8 @@ final class DataFacadeTest extends TestCase
     }
 
     /**
+     * Builds a fake name set matching webtrees output structure.
+     *
      * @return array<int, array<string, string|bool|array<string>>>
      */
     private function buildNameSet(string $firstName, string $lastName): array
@@ -225,6 +238,9 @@ final class DataFacadeTest extends TestCase
         ];
     }
 
+    /**
+     * Creates a date instance with predefined values for testing.
+     */
     private function createDate(string $display): Date
     {
         return new Date($display);

--- a/tests/Model/NodeDataTest.php
+++ b/tests/Model/NodeDataTest.php
@@ -13,12 +13,20 @@ namespace MagicSunday\Webtrees\FanChart\Test\Model;
 
 use MagicSunday\Webtrees\FanChart\Model\NodeData;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(NodeData::class)]
+/**
+ * Tests serialization of node data with all configured fields.
+ */
 final class NodeDataTest extends TestCase
 {
-    public function testJsonSerializeContainsAllConfiguredFields(): void
+    /**
+     * Ensures the serialized payload exposes all configured node data attributes.
+     */
+    #[Test]
+    public function jsonSerializeContainsAllConfiguredFields(): void
     {
         $nodeData = (new NodeData())
             ->setId(42)

--- a/tests/Model/NodeTest.php
+++ b/tests/Model/NodeTest.php
@@ -14,12 +14,20 @@ namespace MagicSunday\Webtrees\FanChart\Test\Model;
 use MagicSunday\Webtrees\FanChart\Model\Node;
 use MagicSunday\Webtrees\FanChart\Model\NodeData;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(Node::class)]
+/**
+ * Tests node serialization logic and parent handling.
+ */
 final class NodeTest extends TestCase
 {
-    public function testJsonSerializeAddsParentsWhenPresent(): void
+    /**
+     * Ensures parent references are included during serialization when they exist.
+     */
+    #[Test]
+    public function jsonSerializeAddsParentsWhenPresent(): void
     {
         $childData  = (new NodeData())->setId(1);
         $fatherData = (new NodeData())->setId(2);
@@ -36,7 +44,11 @@ final class NodeTest extends TestCase
         self::assertSame([$father], $result['parents']);
     }
 
-    public function testJsonSerializeOmitsParentsWhenEmpty(): void
+    /**
+     * Ensures serialization omits parent data when no parents are attached.
+     */
+    #[Test]
+    public function jsonSerializeOmitsParentsWhenEmpty(): void
     {
         $child = new Node(new NodeData());
 

--- a/tests/Module/ModuleTest.php
+++ b/tests/Module/ModuleTest.php
@@ -25,13 +25,21 @@ use Fisharebest\Webtrees\Tree;
 use MagicSunday\Webtrees\FanChart\Facade\DataFacade;
 use MagicSunday\Webtrees\FanChart\Module;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
 #[CoversClass(Module::class)]
+/**
+ * Validates module metadata exposure and chart helpers.
+ */
 final class ModuleTest extends TestCase
 {
-    public function testTraitHelpersExposeExpectedValues(): void
+    /**
+     * Ensures trait-provided helpers return expected metadata and URLs.
+     */
+    #[Test]
+    public function traitHelpersExposeExpectedValues(): void
     {
         $routeFactory = new class implements RouteFactoryInterface {
             public function route(string $route_name, array $parameters = []): string

--- a/tests/Module/VersionInformationTest.php
+++ b/tests/Module/VersionInformationTest.php
@@ -17,13 +17,21 @@ use Fisharebest\Webtrees\Module\ModuleCustomInterface;
 use Fisharebest\Webtrees\Registry;
 use MagicSunday\Webtrees\FanChart\Module\VersionInformation;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 #[CoversClass(VersionInformation::class)]
+/**
+ * Confirms version information retrieval behaviour for the module.
+ */
 final class VersionInformationTest extends TestCase
 {
-    public function testFetchLatestVersionFallsBackToCustomWhenUrlMissing(): void
+    /**
+     * Ensures the current module version is returned when no remote URL is provided.
+     */
+    #[Test]
+    public function fetchLatestVersionFallsBackToCustomWhenUrlMissing(): void
     {
         $factory = new class implements CacheFactoryInterface {
             public function array(): Cache

--- a/tests/Processor/DateProcessorTest.php
+++ b/tests/Processor/DateProcessorTest.php
@@ -18,12 +18,20 @@ use Fisharebest\Webtrees\Individual;
 use Illuminate\Support\Collection;
 use MagicSunday\Webtrees\FanChart\Processor\DateProcessor;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(DateProcessor::class)]
+/**
+ * Validates date processing for individuals and family relationships.
+ */
 final class DateProcessorTest extends TestCase
 {
-    public function testLifetimeDescriptionPrefersBothBirthAndDeathYears(): void
+    /**
+     * Ensures the lifetime description uses both birth and death years when available.
+     */
+    #[Test]
+    public function lifetimeDescriptionPrefersBothBirthAndDeathYears(): void
     {
         $individual = $this->createConfiguredIndividual();
         $processor  = new DateProcessor($individual);
@@ -31,7 +39,11 @@ final class DateProcessorTest extends TestCase
         self::assertSame('1900-1950', $processor->getLifetimeDescription());
     }
 
-    public function testMarriageDatesDecodeHtml(): void
+    /**
+     * Ensures marriage dates decode HTML content for individuals and their parents.
+     */
+    #[Test]
+    public function marriageDatesDecodeHtml(): void
     {
         $individual = $this->createConfiguredIndividual();
         $processor  = new DateProcessor($individual);
@@ -40,6 +52,9 @@ final class DateProcessorTest extends TestCase
         self::assertSame('1 JAN 1880', $processor->getMarriageDateOfParents());
     }
 
+    /**
+     * Creates an individual mock with configurable life events.
+     */
     private function createConfiguredIndividual(
         bool $isDead = true,
         bool $withBirth = true,
@@ -63,6 +78,9 @@ final class DateProcessorTest extends TestCase
         return $individual;
     }
 
+    /**
+     * Creates a date mock with provided display and validation state.
+     */
     private function createDate(int $year, string $display, bool $ok): Date
     {
         $minimumDate = $this->createMock(AbstractCalendarDate::class);
@@ -77,6 +95,8 @@ final class DateProcessorTest extends TestCase
     }
 
     /**
+     * Creates a collection containing the provided family when present.
+     *
      * @return Collection<int, Family>
      */
     private function createCollection(?Family $family): Collection
@@ -84,6 +104,9 @@ final class DateProcessorTest extends TestCase
         return new Collection($family instanceof Family ? [$family] : []);
     }
 
+    /**
+     * Creates a family mock with a preset marriage date.
+     */
     private function createConfiguredFamily(Date $marriageDate): Family
     {
         $family = $this->createMock(Family::class);

--- a/tests/Processor/ImageProcessorTest.php
+++ b/tests/Processor/ImageProcessorTest.php
@@ -17,12 +17,20 @@ use Fisharebest\Webtrees\Module\ModuleCustomInterface;
 use Fisharebest\Webtrees\Tree;
 use MagicSunday\Webtrees\FanChart\Processor\ImageProcessor;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(ImageProcessor::class)]
+/**
+ * Verifies highlight image resolution based on permissions and configuration.
+ */
 final class ImageProcessorTest extends TestCase
 {
-    public function testReturnsHighlightImageWhenAvailable(): void
+    /**
+     * Ensures highlight images are returned when available and visible.
+     */
+    #[Test]
+    public function returnsHighlightImageWhenAvailable(): void
     {
         $mediaFile = $this->createMock(MediaFile::class);
         $mediaFile->method('imageUrl')->with(100, 100, 'contain')->willReturn('/highlight.png');
@@ -40,7 +48,11 @@ final class ImageProcessorTest extends TestCase
         self::assertSame('/highlight.png', $processor->getHighlightImageUrl(100, 100));
     }
 
-    public function testReturnsSilhouetteWhenEnabledAndNoMediaFound(): void
+    /**
+     * Ensures silhouettes are used when highlight images are enabled but missing.
+     */
+    #[Test]
+    public function returnsSilhouetteWhenEnabledAndNoMediaFound(): void
     {
         $tree = $this->createConfiguredTree('1', '1');
 
@@ -57,7 +69,11 @@ final class ImageProcessorTest extends TestCase
         self::assertSame('/silhouette.svg', $processor->getHighlightImageUrl(100, 100));
     }
 
-    public function testReturnsEmptyStringWhenImageNotAllowed(): void
+    /**
+     * Ensures the processor returns an empty string when images are not permitted.
+     */
+    #[Test]
+    public function returnsEmptyStringWhenImageNotAllowed(): void
     {
         $tree = $this->createConfiguredTree('', '');
 
@@ -71,6 +87,9 @@ final class ImageProcessorTest extends TestCase
         self::assertSame('', $processor->getHighlightImageUrl());
     }
 
+    /**
+     * Creates a tree mock with configured image preferences.
+     */
     private function createConfiguredTree(string $highlightPreference, string $silhouettePreference): Tree
     {
         $tree = $this->createMock(Tree::class);
@@ -81,6 +100,9 @@ final class ImageProcessorTest extends TestCase
         return $tree;
     }
 
+    /**
+     * Creates a lightweight module stub returning the provided asset URL.
+     */
     private function createModuleStub(string $assetUrl): ModuleCustomInterface
     {
         return new readonly class($assetUrl) implements ModuleCustomInterface {

--- a/tests/Processor/NameProcessorTest.php
+++ b/tests/Processor/NameProcessorTest.php
@@ -14,12 +14,20 @@ namespace MagicSunday\Webtrees\FanChart\Test\Processor;
 use Fisharebest\Webtrees\Individual;
 use MagicSunday\Webtrees\FanChart\Processor\NameProcessor;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(NameProcessor::class)]
+/**
+ * Verifies name extraction and formatting behaviour.
+ */
 final class NameProcessorTest extends TestCase
 {
-    public function testNameExtractionProvidesFirstLastAndPreferredParts(): void
+    /**
+     * Ensures full, first, and last names are exposed correctly when available.
+     */
+    #[Test]
+    public function nameExtractionProvidesFirstLastAndPreferredParts(): void
     {
         $names = [
             [
@@ -64,7 +72,11 @@ final class NameProcessorTest extends TestCase
         self::assertSame('', $processor->getAlternateName($individual));
     }
 
-    public function testAlternateNameReturnsSecondaryNameWhenDifferent(): void
+    /**
+     * Ensures alternate names return the secondary entry when it differs from primary.
+     */
+    #[Test]
+    public function alternateNameReturnsSecondaryNameWhenDifferent(): void
     {
         $names = [
             [


### PR DESCRIPTION
M# Sweep — Verify compliance for this milestone

### Summary
- Converted PHPUnit tests to attribute-based declarations and renamed methods for descriptive coverage intentions.
- Added PHPDoc summaries across test classes and helper methods.

### Testing
- composer ci:test:php:unit


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923504e309c83238087227d655eb46e)