### PR TITLE
feat: modularize fan chart renderer

### DIFF
--- a/resources/js/modules/custom/data-loader.js
+++ b/resources/js/modules/custom/data-loader.js
@@ -1,0 +1,39 @@
+/**
+ * This file is part of the package magicsunday/webtrees-fan-chart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+import * as d3 from "../lib/d3";
+
+/**
+ * Handles loading and normalizing chart data.
+ */
+export default class DataLoader
+{
+    /**
+     * Loads hierarchy data from a remote endpoint.
+     *
+     * @param {string} url
+     *
+     * @returns {Promise<Object>}
+     */
+    fetchHierarchy(url)
+    {
+        return d3.json(url)
+            .then((data) => this.normalize(data));
+    }
+
+    /**
+     * Normalizes the hierarchy payload.
+     *
+     * @param {Object} payload
+     *
+     * @returns {Object}
+     */
+    normalize(payload)
+    {
+        return payload;
+    }
+}

--- a/resources/js/modules/custom/export-service.js
+++ b/resources/js/modules/custom/export-service.js
@@ -1,0 +1,50 @@
+/**
+ * This file is part of the package magicsunday/webtrees-fan-chart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+/**
+ * Handles exporting charts.
+ */
+export default class ExportService
+{
+    /**
+     * @param {string[]} cssFiles
+     */
+    constructor(cssFiles = [])
+    {
+        this._cssFiles = cssFiles;
+    }
+
+    /**
+     * Exports the given SVG instance.
+     *
+     * @param {string} type
+     * @param {Svg} svg
+     */
+    export(type, svg)
+    {
+        if (!svg) {
+            return;
+        }
+
+        if (type === "png") {
+            svg
+                .export(type)
+                .svgToImage(svg, "fan-chart.png");
+
+            return;
+        }
+
+        svg
+            .export(type)
+            .svgToImage(
+                svg,
+                this._cssFiles,
+                "webtrees-fan-chart-container",
+                "fan-chart.svg"
+            );
+    }
+}

--- a/resources/js/modules/custom/layout-engine.js
+++ b/resources/js/modules/custom/layout-engine.js
@@ -1,0 +1,65 @@
+/**
+ * This file is part of the package magicsunday/webtrees-fan-chart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+import Hierarchy from "./hierarchy";
+import Geometry from "./svg/geometry";
+import ArcFactory from "./svg/segments/arc-factory";
+
+/**
+ * Coordinates geometry helpers and hierarchical data.
+ */
+export default class LayoutEngine
+{
+    /**
+     * @param {Configuration} configuration
+     */
+    constructor(configuration)
+    {
+        this._configuration = configuration;
+        this._hierarchy     = new Hierarchy(this._configuration);
+        this._geometry      = new Geometry(this._configuration);
+        this._arcFactory    = new ArcFactory(this._geometry, {
+            padAngle: this._configuration.padAngle,
+            padRadius: this._configuration.padRadius,
+            cornerRadius: this._configuration.cornerRadius,
+        });
+    }
+
+    /**
+     * Initializes hierarchy data and prepares geometry helpers.
+     *
+     * @param {Object} data
+     */
+    initializeHierarchy(data)
+    {
+        this._hierarchy.init(data);
+    }
+
+    /**
+     * @returns {Hierarchy}
+     */
+    get hierarchy()
+    {
+        return this._hierarchy;
+    }
+
+    /**
+     * @returns {Geometry}
+     */
+    get geometry()
+    {
+        return this._geometry;
+    }
+
+    /**
+     * @returns {ArcFactory}
+     */
+    get arcFactory()
+    {
+        return this._arcFactory;
+    }
+}

--- a/resources/js/modules/custom/view-layer.js
+++ b/resources/js/modules/custom/view-layer.js
@@ -1,0 +1,222 @@
+/**
+ * This file is part of the package magicsunday/webtrees-fan-chart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+import * as d3 from "../lib/d3";
+import Overlay from "../lib/chart/overlay";
+import Svg from "./svg";
+import Person from "./svg/person";
+import Gradient from "./gradient";
+
+const MIN_PADDING = 1;
+
+/**
+ * Creates and manages the SVG view layer.
+ */
+export default class ViewLayer
+{
+    /**
+     * @param {Configuration} configuration
+     */
+    constructor(configuration)
+    {
+        this._configuration = configuration;
+        this._parent        = null;
+        this._svg           = null;
+        this._overlay       = null;
+        this._gradient      = null;
+    }
+
+    /**
+     * @returns {Svg|null}
+     */
+    get svg()
+    {
+        return this._svg;
+    }
+
+    /**
+     * Prepares the SVG, overlay, and person elements.
+     *
+     * @param {Selection} parent
+     * @param {LayoutEngine} layoutEngine
+     */
+    render(parent, layoutEngine)
+    {
+        this._parent   = parent;
+        this._svg      = new Svg(this._parent, this._configuration);
+        this._overlay  = new Overlay(this._parent);
+        this._gradient = new Gradient(this._svg, this._configuration);
+
+        this._svg.initEvents(this._overlay);
+
+        this.renderPersons(layoutEngine);
+        this.updateViewBox();
+        this.bindClickEventListener();
+    }
+
+    /**
+     * Convert relative root element's font-size into pixel size.
+     *
+     * @param {number} rem The relative size
+     *
+     * @returns {number}
+     */
+    convertRemToPixels(rem)
+    {
+        return rem * parseFloat(window.getComputedStyle(document.documentElement).fontSize);
+    }
+
+    /**
+     * Update/Calculate the viewBox attribute of the SVG element.
+     */
+    updateViewBox()
+    {
+        if (!this._svg) {
+            return;
+        }
+
+        this._svg
+            .attr("width", "100%")
+            .attr("height", "100%");
+
+        const padding = this.convertRemToPixels(MIN_PADDING);
+
+        let svgBoundingBox    = this._svg.visual.node().getBBox();
+        let clientBoundingBox = this._parent.node().getBoundingClientRect();
+
+        let viewBoxWidth  = Math.max(clientBoundingBox.width, svgBoundingBox.width);
+        let viewBoxHeight = Math.max(clientBoundingBox.height, svgBoundingBox.height);
+
+        if (document.fullscreenElement) {
+            viewBoxWidth = Math.max(svgBoundingBox.width, Math.min(clientBoundingBox.width, svgBoundingBox.width));
+            viewBoxHeight = Math.max(svgBoundingBox.height, Math.min(clientBoundingBox.height, svgBoundingBox.height));
+        }
+
+        let offsetX = (viewBoxWidth - svgBoundingBox.width) >> 1;
+        let offsetY = (viewBoxHeight - svgBoundingBox.height) >> 1;
+
+        let viewBoxLeft = Math.ceil(svgBoundingBox.x - offsetX - padding);
+        let viewBoxTop  = Math.ceil(svgBoundingBox.y - offsetY - padding);
+
+        if (document.fullscreenElement) {
+            this._svg
+                .attr("width", clientBoundingBox.width)
+                .attr("height", clientBoundingBox.height);
+        }
+
+        viewBoxWidth  = Math.ceil(viewBoxWidth + (padding << 1));
+        viewBoxHeight = Math.ceil(viewBoxHeight + (padding << 1));
+
+        this._svg
+            .attr(
+                "viewBox",
+                [
+                    viewBoxLeft,
+                    viewBoxTop,
+                    viewBoxWidth,
+                    viewBoxHeight
+                ]
+            );
+    }
+
+    /**
+     * Resets the chart to initial zoom level and position.
+     */
+    center()
+    {
+        if (!this._svg) {
+            return;
+        }
+
+        this._svg
+            .transition()
+            .duration(750)
+            .call(this._svg.zoom.get().transform, d3.zoomIdentity);
+    }
+
+    /**
+     * Binds click listeners to person elements.
+     */
+    bindClickEventListener()
+    {
+        this._svg
+            .select("g.personGroup")
+            .selectAll("g.person")
+            .filter((datum) => datum.data.data.xref !== "")
+            .classed("available", true)
+            .on("click", this.personClick.bind(this));
+    }
+
+    /**
+     * @param {Event} event
+     * @param {Object} datum
+     *
+     * @private
+     */
+    personClick(event, datum)
+    {
+        (datum.depth === 0) ? this.redirectToIndividual(datum.data.data.url) : this.update(datum.data.data.updateUrl);
+    }
+
+    /**
+     * Redirects to the individual page.
+     *
+     * @param {string} url The individual URL
+     *
+     * @private
+     */
+    redirectToIndividual(url)
+    {
+        window.open(url, "_blank");
+    }
+
+    /**
+     * Hooks update handling for external listeners.
+     *
+     * @param {Function} callback
+     */
+    onUpdate(callback)
+    {
+        this.update = callback;
+    }
+
+    /**
+     * Renders all person nodes.
+     *
+     * @param {LayoutEngine} layoutEngine
+     */
+    renderPersons(layoutEngine)
+    {
+        if (!this._svg) {
+            return;
+        }
+
+        const personGroup = this._svg.select("g.personGroup");
+        const nodes       = layoutEngine.hierarchy.nodes;
+
+        personGroup
+            .selectAll("g.person")
+            .data(nodes, (datum) => datum.id)
+            .enter()
+            .filter((datum) => (datum.data.data.xref !== "") || !this._configuration.hideEmptySegments)
+            .append("g")
+            .attr("class", "person")
+            .attr("id", (datum) => "person-" + datum.id);
+
+        personGroup
+            .selectAll("g.person")
+            .each((datum, index, nodesList) => {
+                const person = d3.select(nodesList[index]);
+
+                if (this._configuration.showColorGradients) {
+                    this._gradient.init(datum);
+                }
+
+                new Person(this._svg, this._configuration, layoutEngine.arcFactory, layoutEngine.geometry, person, datum);
+            });
+    }
+}

--- a/resources/js/tests/modules/custom/update.test.js
+++ b/resources/js/tests/modules/custom/update.test.js
@@ -394,6 +394,13 @@ const createArcFactory = () => ({
     createOverlayArc: jest.fn(() => ({})),
 });
 
+const createLayoutEngine = (hierarchy, arcFactory = createArcFactory()) => ({
+    hierarchy,
+    arcFactory,
+    geometry: {},
+    initializeHierarchy: (data) => hierarchy.init(data),
+});
+
 beforeEach(() => {
     jsonMock.mockReset();
     timerMock.mockClear();
@@ -408,10 +415,11 @@ beforeEach(() => {
 
 describe("Update", () => {
     test("removes existing handlers before fetching and updates titles", async () => {
-        const svg         = createSvgWithPersons(["1"]);
-        const hierarchy   = new HierarchyStub();
+        const svg           = createSvgWithPersons(["1"]);
+        const hierarchy     = new HierarchyStub();
+        const layoutEngine  = createLayoutEngine(hierarchy);
         const configuration = defaultConfiguration();
-        const update      = new Update(svg, configuration, hierarchy, createArcFactory());
+        const update        = new Update(svg, configuration, layoutEngine);
         const titleHtml   = "<strong>Updated</strong>";
         const callback    = jest.fn();
 
@@ -440,8 +448,9 @@ describe("Update", () => {
     test("assigns classes based on data and applies transition styles", async () => {
         const svg           = createSvgWithPersons(["1"]);
         const hierarchy     = new HierarchyStub();
+        const layoutEngine  = createLayoutEngine(hierarchy);
         const configuration = defaultConfiguration();
-        const update        = new Update(svg, configuration, hierarchy, createArcFactory());
+        const update        = new Update(svg, configuration, layoutEngine);
         const callback      = jest.fn();
 
         jsonMock.mockResolvedValueOnce({
@@ -495,8 +504,9 @@ describe("Update", () => {
     test("hides empty segments and cleans up after transitions", async () => {
         const svg           = createSvgWithPersons(["1", "2"]);
         const hierarchy     = new HierarchyStub();
+        const layoutEngine  = createLayoutEngine(hierarchy);
         const configuration = defaultConfiguration({ hideEmptySegments: true });
-        const update        = new Update(svg, configuration, hierarchy, createArcFactory());
+        const update        = new Update(svg, configuration, layoutEngine);
         const callback      = jest.fn();
 
         jsonMock.mockResolvedValueOnce({


### PR DESCRIPTION
M# Sweep — Verify compliance for this milestone

## Summary
- introduce dedicated data loader, layout engine, view layer, and export service modules for the fan chart
- refactor fan chart renderer to compose new collaborators and adjust update handling
- refresh related tests to reflect modular architecture and default data loading behavior

## Testing
- npm test -- --runTestsByPath resources/js/tests/modules/custom/update.test.js resources/js/tests/modules/fan-chart-renderer.test.js
- npm test (fails: Playwright browsers not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923fe2c38b083239adca0faa874b9c5)