### PR TITLE
Fix coercion of stored fan chart options

### DIFF
--- a/resources/js/modules/custom/fan-chart-options.js
+++ b/resources/js/modules/custom/fan-chart-options.js
@@ -71,9 +71,21 @@ const toStringArray = (value = []) => Array.isArray(value)
     ? value.filter((item) => typeof item === "string")
     : [];
 
-const toFiniteNumber = (value, fallback) => (typeof value === "number" && Number.isFinite(value))
-    ? value
-    : fallback;
+const toFiniteNumber = (value, fallback) => {
+    if (typeof value === "number" && Number.isFinite(value)) {
+        return value;
+    }
+
+    if (typeof value === "string" && value.trim() !== "") {
+        const parsed = Number(value);
+
+        if (Number.isFinite(parsed)) {
+            return parsed;
+        }
+    }
+
+    return fallback;
+};
 
 const toBoolean = (value, fallback) => typeof value === "boolean"
     ? value

--- a/resources/js/tests/modules/custom/fan-chart-options.test.js
+++ b/resources/js/tests/modules/custom/fan-chart-options.test.js
@@ -35,6 +35,18 @@ describe("resolveFanChartOptions", () => {
         expect(resolved.controls).toBeUndefined();
     });
 
+    it("coerces numeric string options to finite numbers", () => {
+        const resolved = resolveFanChartOptions({
+            fanDegree: "275",
+            fontScale: "125.5",
+            innerArcs: "3",
+        });
+
+        expect(resolved.fanDegree).toBe(275);
+        expect(resolved.fontScale).toBeCloseTo(125.5);
+        expect(resolved.innerArcs).toBe(3);
+    });
+
     it("collects inline callbacks when no controls object is provided", () => {
         const onRender = jest.fn();
         const resolved = resolveFanChartOptions({ onRender });

--- a/resources/js/tests/modules/index.test.js
+++ b/resources/js/tests/modules/index.test.js
@@ -73,6 +73,23 @@ describe("createFanChart", () => {
         expect(ctorArgs[0].configuration).toBeInstanceOf(Configuration);
     });
 
+    it("applies numeric string options to the renderer and configuration", () => {
+        createFanChart(createOptions({
+            fanDegree: "300",
+            fontScale: "125",
+            innerArcs: "2",
+        }));
+
+        const rendererOptions = ctorArgs[0];
+
+        expect(rendererOptions.fanDegree).toBe(300);
+        expect(rendererOptions.fontScale).toBe(125);
+        expect(rendererOptions.innerArcs).toBe(2);
+        expect(rendererOptions.configuration.fanDegree).toBe(300);
+        expect(rendererOptions.configuration.fontScale).toBe(125);
+        expect(rendererOptions.configuration.numberOfInnerCircles).toBe(2);
+    });
+
     it("forwards callbacks so the host can trigger renderer actions", () => {
         const renderCallbacks = [];
         const resizeCallbacks = [];

--- a/resources/views/modules/fan-chart/page.phtml
+++ b/resources/views/modules/fan-chart/page.phtml
@@ -152,6 +152,20 @@ function toggleMoreOptions(storage)
     }
 }
 
+/**
+ * Parses a stored value into a finite number.
+ *
+ * @param {unknown} value
+ *
+ * @returns {number|undefined}
+ */
+function toStoredNumber(value)
+{
+    const parsedValue = Number(value);
+
+    return Number.isFinite(parsedValue) ? parsedValue : undefined;
+}
+
 // Set up storage object
 const storage = new WebtreesFanChart.Storage("webtrees-fan-chart");
 
@@ -168,15 +182,18 @@ storage.register("fontScale");
 toggleMoreOptions(storage);
 
 // Set initial stored value for radio button group
-document.getElementById("fanDegreeOutput").value = parseInt(storage.read("fanDegree")) + "°";
+const storedFanDegree = toStoredNumber(storage.read("fanDegree"));
+const defaultFanDegree = Number.parseInt(document.getElementById("fanDegree").value, 10);
 
-const fanDegree               = storage.read("fanDegree");
+document.getElementById("fanDegreeOutput").value = `${storedFanDegree ?? defaultFanDegree}°`;
+
+const fanDegree               = storedFanDegree;
 const generations             = parseInt(storage.read("generations"));
 const hideEmptySegments       = storage.read("hideEmptySegments");
 const showColorGradients      = storage.read("showColorGradients");
 const showParentMarriageDates = storage.read("showParentMarriageDates");
-const innerArcs               = storage.read("innerArcs");
-const fontScale               = storage.read("fontScale");
+const innerArcs               = toStoredNumber(storage.read("innerArcs"));
+const fontScale               = toStoredNumber(storage.read("fontScale"));
 const ajaxUrl                 = getUrl(<?= json_encode($ajaxUrl) ?>, storage.read("generations"));
 
 document.getElementById("fan-chart-url")


### PR DESCRIPTION
M# Sweep — Verify compliance for this milestone

## Summary
- convert stored fan chart numeric options to finite numbers before resolving configuration
- coerce numeric strings within option resolution to preserve user selections
- extend unit coverage for numeric string inputs and configuration propagation

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69240a37628c8323a3c99d4115e6e4ac)