### PR TITLE
Add padding around fullscreen fan chart

### DIFF
--- a/resources/css/fan-chart.css
+++ b/resources/css/fan-chart.css
@@ -236,7 +236,8 @@ div.tooltip .date {
 
 /* Fullscreen */
 [fullscreen] .webtrees-fan-fullscreen-container .wt-page-content {
-    padding: 0;
+    padding: 10px;
+    box-sizing: border-box;
 }
 
 [fullscreen] .webtrees-fan-fullscreen-container .btn-toolbar {
@@ -265,6 +266,6 @@ div.tooltip .date {
 }
 
 [fullscreen] .webtrees-fan-chart-container {
-    min-height: 100dvh;
-    max-height: 100dvh;
+    min-height: calc(100dvh - 20px);
+    max-height: calc(100dvh - 20px);
 }


### PR DESCRIPTION
M# Sweep — Verify compliance for this milestone

## Summary
- add a 10px padding buffer around the chart when in fullscreen mode
- adjust fullscreen chart height calculations to account for the new padding

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692436f7f980832395e7be5613ee3838)