### PR TITLE
Refactor renderer dependency injection

### DIFF
--- a/resources/js/modules/custom/dependencies.js
+++ b/resources/js/modules/custom/dependencies.js
@@ -1,0 +1,49 @@
+/**
+ * This file is part of the package magicsunday/webtrees-fan-chart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+import DataLoader from "./data-loader";
+import D3ChartExporter from "./export/d3-chart-exporter";
+import LayoutEngine from "./layout-engine";
+import ViewLayer from "./view-layer";
+import ViewportEventService from "./viewport-event-service";
+
+/**
+ * @typedef {import("./service-contracts").FanChartDependencies} FanChartDependencies
+ */
+
+/**
+ * Build the default dependency bundle for the fan chart renderer.
+ *
+ * @param {object} options Dependency construction options.
+ * @param {import("./configuration").default} options.configuration Resolved fan chart configuration.
+ * @param {Array<string>} options.cssFiles CSS files to include in exports.
+ * @param {(Partial<FanChartDependencies> & { exportService?: import("./service-contracts").FanChartExportService })} [options.overrides]
+ *     Optional overrides for dependency instances.
+ * @param {() => import("../lib/d3").Selection|null|undefined} [options.getContainer] Provider for the chart container selection.
+ * @returns {FanChartDependencies} Instantiated dependencies for the fan chart renderer.
+ */
+export const createDefaultDependencies = ({ configuration, cssFiles, overrides = {}, getContainer }) => {
+    const viewLayer = overrides.viewLayer ?? new ViewLayer(configuration);
+    const layoutEngine = overrides.layoutEngine ?? new LayoutEngine(configuration);
+    const dataLoader = overrides.dataLoader ?? new DataLoader();
+    const chartExporter = overrides.chartExporter ?? overrides.exportService ?? new D3ChartExporter(cssFiles ?? []);
+    const viewportService = overrides.viewportService ?? new ViewportEventService({
+        getContainer,
+        onUpdateViewBox: () => viewLayer.updateViewBox(),
+        onCenter: () => viewLayer.center(),
+    });
+
+    return {
+        viewLayer,
+        layoutEngine,
+        dataLoader,
+        chartExporter,
+        viewportService,
+    };
+};
+
+export default createDefaultDependencies;

--- a/resources/js/modules/custom/service-contracts.js
+++ b/resources/js/modules/custom/service-contracts.js
@@ -50,4 +50,13 @@
  * @typedef {ViewportEventService} FanChartViewportService
  */
 
+/**
+ * @typedef {object} FanChartDependencies
+ * @property {FanChartViewLayer} viewLayer
+ * @property {FanChartLayoutEngine} layoutEngine
+ * @property {FanChartDataLoader} dataLoader
+ * @property {FanChartExportService} chartExporter
+ * @property {FanChartViewportService} viewportService
+ */
+
 export {};

--- a/resources/js/modules/fan-chart-renderer.js
+++ b/resources/js/modules/fan-chart-renderer.js
@@ -5,19 +5,15 @@
  * LICENSE file that was distributed with this source code.
  */
 
-import DataLoader from "./custom/data-loader";
-import D3ChartExporter from "./custom/export/d3-chart-exporter";
 import { FAN_CHART_BASE_DEFAULTS } from "./custom/fan-chart-definitions";
-import LayoutEngine from "./custom/layout-engine";
-import ViewLayer from "./custom/view-layer";
 import Update from "./custom/update";
-import ViewportEventService from "./custom/viewport-event-service";
 
 /**
  * @typedef {import("./custom/service-contracts").FanChartLayoutEngine} FanChartLayoutEngine
  * @typedef {import("./custom/service-contracts").FanChartViewLayer} FanChartViewLayer
  * @typedef {import("./custom/service-contracts").FanChartDataLoader} FanChartDataLoader
  * @typedef {import("./custom/service-contracts").FanChartExportService} FanChartExportService
+ * @typedef {import("./custom/service-contracts").FanChartDependencies} FanChartDependencies
  */
 
 /**
@@ -26,26 +22,25 @@ import ViewportEventService from "./custom/viewport-event-service";
 export default class FanChartRenderer
 {
     /**
-     * @param {import("./custom/fan-chart-options").ResolvedFanChartOptions} options
+     * @param {object} options
+     * @param {import("./custom/service-contracts").FanChartD3} [options.d3]
+     * @param {string} options.selector
+     * @param {import("./custom/configuration").default} options.configuration
+     * @param {object} [options.data]
+     * @param {FanChartDependencies} options.services
      */
-    constructor(options) {
-        this._d3             = options.d3 ?? FAN_CHART_BASE_DEFAULTS.d3;
-        this._selector       = options.selector;
-        this._configuration  = options.configuration;
-        this._data           = options.data;
-        this._cssFiles       = options.cssFiles ?? [];
-        this._parent         = null;
-        this._viewLayer      = /** @type {FanChartViewLayer} */ (options.viewLayer ?? new ViewLayer(this._configuration));
-        this._layoutEngine   = /** @type {FanChartLayoutEngine} */ (options.layoutEngine ?? new LayoutEngine(this._configuration));
-        this._dataLoader     = /** @type {FanChartDataLoader} */ (options.dataLoader ?? new DataLoader());
-        this._chartExporter  = /** @type {FanChartExportService} */ (options.chartExporter ?? options.exportService ?? new D3ChartExporter(this._cssFiles));
-        this._viewportService = /** @type {import("./custom/service-contracts").ViewportEventService} */ (
-            options.viewportService ?? new ViewportEventService({
-                getContainer: () => this._parent,
-                onUpdateViewBox: () => this._viewLayer.updateViewBox(),
-                onCenter: () => this._viewLayer.center(),
-            })
-        );
+    constructor({ d3 = FAN_CHART_BASE_DEFAULTS.d3, selector, configuration, data, services }) {
+        this._d3            = d3;
+        this._selector      = selector;
+        this._configuration = configuration;
+        this._data          = data;
+        this._parent        = null;
+        this._services      = services;
+        this._viewLayer     = /** @type {FanChartViewLayer} */ (services.viewLayer);
+        this._layoutEngine  = /** @type {FanChartLayoutEngine} */ (services.layoutEngine);
+        this._dataLoader    = /** @type {FanChartDataLoader} */ (services.dataLoader);
+        this._chartExporter = /** @type {FanChartExportService} */ (services.chartExporter);
+        this._viewportService = /** @type {import("./custom/service-contracts").ViewportEventService} */ (services.viewportService);
     }
 
     /**

--- a/resources/js/modules/renderer-factory.js
+++ b/resources/js/modules/renderer-factory.js
@@ -6,6 +6,7 @@
  */
 
 import Configuration from "./custom/configuration";
+import { createDefaultDependencies } from "./custom/dependencies";
 import { resolveFanChartOptions } from "./custom/fan-chart-options";
 import FanChartRenderer from "./fan-chart-renderer";
 
@@ -48,9 +49,27 @@ export const createRendererActions = (renderer) => ({
 export const createRenderer = (options = {}, hooks = {}) => {
     const resolvedOptions = resolveFanChartOptions(options);
     const configuration   = createConfiguration(resolvedOptions);
-    const renderer = new FanChartRenderer({
-        ...resolvedOptions,
+    let renderer;
+    const services = createDefaultDependencies({
         configuration,
+        cssFiles: resolvedOptions.cssFiles,
+        overrides: {
+            viewLayer: resolvedOptions.viewLayer,
+            layoutEngine: resolvedOptions.layoutEngine,
+            dataLoader: resolvedOptions.dataLoader,
+            chartExporter: resolvedOptions.chartExporter,
+            exportService: resolvedOptions.exportService,
+            viewportService: resolvedOptions.viewportService,
+        },
+        getContainer: () => renderer?._parent ?? null,
+    });
+    renderer = new FanChartRenderer({
+        d3: resolvedOptions.d3,
+        selector: resolvedOptions.selector,
+        configuration,
+        data: resolvedOptions.data,
+        cssFiles: resolvedOptions.cssFiles,
+        services,
     });
 
     hooks.onCreated?.(renderer);

--- a/resources/js/tests/modules/custom/dependencies.test.js
+++ b/resources/js/tests/modules/custom/dependencies.test.js
@@ -1,0 +1,121 @@
+import { jest } from "@jest/globals";
+
+const viewLayerConstructor = jest.fn();
+const layoutEngineConstructor = jest.fn();
+const dataLoaderConstructor = jest.fn();
+const exporterConstructor = jest.fn();
+const viewportConstructor = jest.fn();
+const viewportInstance = { register: jest.fn(), resize: jest.fn(), center: jest.fn() };
+let viewportOptions;
+
+await jest.unstable_mockModule("resources/js/modules/custom/view-layer", () => ({
+    __esModule: true,
+    default: jest.fn((...args) => {
+        viewLayerConstructor(...args);
+
+        return {
+            render: jest.fn(),
+            updateViewBox: jest.fn(),
+            center: jest.fn(),
+            onUpdate: jest.fn(),
+            bindClickEventListener: jest.fn(),
+            svg: null,
+        };
+    }),
+}));
+
+await jest.unstable_mockModule("resources/js/modules/custom/layout-engine", () => ({
+    __esModule: true,
+    default: jest.fn((...args) => {
+        layoutEngineConstructor(...args);
+
+        return { initializeHierarchy: jest.fn() };
+    }),
+}));
+
+await jest.unstable_mockModule("resources/js/modules/custom/data-loader", () => ({
+    __esModule: true,
+    default: jest.fn((...args) => {
+        dataLoaderConstructor(...args);
+
+        return { fetchHierarchy: jest.fn() };
+    }),
+}));
+
+await jest.unstable_mockModule("resources/js/modules/custom/export/d3-chart-exporter", () => ({
+    __esModule: true,
+    default: jest.fn((...args) => {
+        exporterConstructor(...args);
+
+        return { export: jest.fn() };
+    }),
+}));
+
+await jest.unstable_mockModule("resources/js/modules/custom/viewport-event-service", () => ({
+    __esModule: true,
+    default: jest.fn((options) => {
+        viewportOptions = options;
+        viewportConstructor(options);
+
+        return viewportInstance;
+    }),
+}));
+
+const { createDefaultDependencies } = await import("resources/js/modules/custom/dependencies");
+
+const configuration = { id: "config" };
+const cssFiles = ["fan.css"];
+
+beforeEach(() => {
+    viewLayerConstructor.mockClear();
+    layoutEngineConstructor.mockClear();
+    dataLoaderConstructor.mockClear();
+    exporterConstructor.mockClear();
+    viewportConstructor.mockClear();
+    viewportInstance.center.mockClear();
+    viewportInstance.register.mockClear();
+    viewportInstance.resize.mockClear();
+});
+
+describe("createDefaultDependencies", () => {
+    it("creates default service instances with callbacks wired to the view layer", () => {
+        const getContainer = jest.fn();
+        const dependencies = createDefaultDependencies({ configuration, cssFiles, getContainer });
+
+        expect(viewLayerConstructor).toHaveBeenCalledWith(configuration);
+        expect(layoutEngineConstructor).toHaveBeenCalledWith(configuration);
+        expect(dataLoaderConstructor).toHaveBeenCalledTimes(1);
+        expect(exporterConstructor).toHaveBeenCalledWith(cssFiles);
+        expect(viewportConstructor).toHaveBeenCalledWith({
+            getContainer,
+            onUpdateViewBox: expect.any(Function),
+            onCenter: expect.any(Function),
+        });
+
+        viewportOptions.onUpdateViewBox();
+        viewportOptions.onCenter();
+
+        expect(dependencies.viewLayer.updateViewBox).toHaveBeenCalledTimes(1);
+        expect(dependencies.viewLayer.center).toHaveBeenCalledTimes(1);
+    });
+
+    it("prefers externally supplied service overrides", () => {
+        const overrides = {
+            viewLayer: { render: jest.fn() },
+            layoutEngine: { initializeHierarchy: jest.fn() },
+            dataLoader: { fetchHierarchy: jest.fn() },
+            chartExporter: { export: jest.fn() },
+            viewportService: { register: jest.fn(), resize: jest.fn(), center: jest.fn() },
+        };
+
+        const dependencies = createDefaultDependencies({ configuration, cssFiles, overrides });
+
+        expect(viewLayerConstructor).not.toHaveBeenCalled();
+        expect(layoutEngineConstructor).not.toHaveBeenCalled();
+        expect(dataLoaderConstructor).not.toHaveBeenCalled();
+        expect(exporterConstructor).not.toHaveBeenCalled();
+        expect(viewportConstructor).not.toHaveBeenCalled();
+
+        expect(dependencies).toMatchObject(overrides);
+    });
+});

--- a/resources/js/tests/modules/fan-chart-renderer.test.js
+++ b/resources/js/tests/modules/fan-chart-renderer.test.js
@@ -1,49 +1,9 @@
 import { jest } from "@jest/globals";
 
-const selectMock         = jest.fn();
-const layoutMock         = jest.fn();
-const viewLayerMock      = jest.fn();
-const exporterMock       = jest.fn();
-const dataLoaderMock     = jest.fn();
-const updateConstructor  = jest.fn();
-const viewportCtorMock   = jest.fn();
-const parentNode         = { contains: jest.fn(() => false) };
-
-class StubLayoutEngine {
-    constructor(configuration)
-    {
-        this.configuration       = configuration;
-        this.initializeHierarchy = jest.fn();
-    }
-}
-
-class StubDataLoader {
-    constructor(...args)
-    {
-        dataLoaderMock(...args);
-        this.fetchHierarchy = jest.fn();
-    }
-}
-
-class StubViewLayer {
-    constructor(configuration)
-    {
-        this.configuration          = configuration;
-        this.render                 = jest.fn();
-        this.updateViewBox          = jest.fn();
-        this.center                 = jest.fn();
-        this.onUpdate               = jest.fn((callback) => { this.updateCallback = callback; });
-        this.bindClickEventListener = jest.fn();
-        this.svg                    = { tag: "svg" };
-    }
-}
-
-class StubChartExporter {
-    constructor()
-    {
-        this.export = jest.fn();
-    }
-}
+const selectMock        = jest.fn();
+const updateConstructor = jest.fn();
+const parentNode        = { contains: jest.fn(() => false) };
+const configuration     = { id: "config" };
 
 class StubUpdate {
     constructor(...args)
@@ -53,170 +13,110 @@ class StubUpdate {
     }
 }
 
-const viewportServiceInstance = { register: jest.fn(), resize: jest.fn(), center: jest.fn() };
-let viewportOptions;
-
-await jest.unstable_mockModule("resources/js/modules/lib/d3", () => ({
-    __esModule: true,
-    select: selectMock,
-}));
-
-await jest.unstable_mockModule("resources/js/modules/custom/layout-engine", () => ({
-    __esModule: true,
-    default: jest.fn((...args) => {
-        layoutMock(...args);
-        return new StubLayoutEngine(...args);
-    }),
-}));
-
-await jest.unstable_mockModule("resources/js/modules/custom/view-layer", () => ({
-    __esModule: true,
-    default: jest.fn((...args) => {
-        viewLayerMock(...args);
-        return new StubViewLayer(...args);
-    }),
-}));
-
-await jest.unstable_mockModule("resources/js/modules/custom/export/d3-chart-exporter", () => ({
-    __esModule: true,
-    default: jest.fn((...args) => {
-        exporterMock(...args);
-        return new StubChartExporter(...args);
-    }),
-}));
-
-await jest.unstable_mockModule("resources/js/modules/custom/data-loader", () => ({
-    __esModule: true,
-    default: jest.fn((...args) => new StubDataLoader(...args)),
-}));
-
 await jest.unstable_mockModule("resources/js/modules/custom/update", () => ({
     __esModule: true,
     default: StubUpdate,
 }));
 
-await jest.unstable_mockModule("resources/js/modules/custom/viewport-event-service", () => ({
-    __esModule: true,
-    default: jest.fn((options) => {
-        viewportOptions = options;
-        viewportCtorMock(options);
-        return viewportServiceInstance;
-    }),
-}));
-
 const { default: FanChartRenderer } = await import("resources/js/modules/fan-chart-renderer");
+
+const createServiceBundle = () => {
+    const viewLayer = {
+        render: jest.fn(),
+        updateViewBox: jest.fn(),
+        center: jest.fn(),
+        onUpdate: jest.fn((callback) => {
+            viewLayer.updateCallback = callback;
+        }),
+        bindClickEventListener: jest.fn(),
+        svg: { tag: "svg" },
+    };
+    const layoutEngine = { initializeHierarchy: jest.fn() };
+    const dataLoader = { fetchHierarchy: jest.fn() };
+    const chartExporter = { export: jest.fn() };
+    const viewportService = { register: jest.fn(), resize: jest.fn(), center: jest.fn() };
+
+    return {
+        viewLayer,
+        layoutEngine,
+        dataLoader,
+        chartExporter,
+        viewportService,
+    };
+};
 
 const baseOptions = {
     selector: "#chart",
-    configuration: {},
+    configuration,
     data: { id: "I1" },
     cssFiles: ["fan.css"],
 };
+
+const createRenderer = (services = createServiceBundle()) => new FanChartRenderer({
+    ...baseOptions,
+    d3: { select: selectMock },
+    services,
+});
 
 describe("FanChartRenderer", () => {
     beforeEach(() => {
         parentNode.contains.mockReturnValue(false);
         selectMock.mockReturnValue({ tag: "parent", node: () => parentNode });
         selectMock.mockClear();
-        layoutMock.mockClear();
-        viewLayerMock.mockClear();
-        exporterMock.mockClear();
-        dataLoaderMock.mockClear();
         updateConstructor.mockClear();
-        viewportCtorMock.mockClear();
-        viewportServiceInstance.register.mockClear();
-        viewportServiceInstance.resize.mockClear();
-        viewportServiceInstance.center.mockClear();
     });
 
-    it("renders with injected d3, draws the chart, and registers viewport listeners", () => {
-        const renderer = new FanChartRenderer({ ...baseOptions, d3: { select: selectMock } });
+    it("renders with injected dependencies and registers viewport listeners", () => {
+        const services = createServiceBundle();
+        const renderer = createRenderer(services);
 
         renderer.render();
 
         expect(selectMock).toHaveBeenCalledWith("#chart");
-        expect(layoutMock).toHaveBeenCalledWith(baseOptions.configuration);
-        expect(viewLayerMock).toHaveBeenCalledWith(baseOptions.configuration);
-        expect(renderer._layoutEngine.initializeHierarchy).toHaveBeenCalledWith(baseOptions.data);
-        expect(renderer._viewLayer.render).toHaveBeenCalledWith({ tag: "parent", node: expect.any(Function) }, renderer._layoutEngine);
-        expect(viewportCtorMock).toHaveBeenCalledWith({
-            getContainer: expect.any(Function),
-            onUpdateViewBox: expect.any(Function),
-            onCenter: expect.any(Function),
-        });
-        expect(viewportServiceInstance.register).toHaveBeenCalledTimes(1);
+        expect(services.layoutEngine.initializeHierarchy).toHaveBeenCalledWith(baseOptions.data);
+        expect(services.viewLayer.render).toHaveBeenCalledWith({ tag: "parent", node: expect.any(Function) }, services.layoutEngine);
+        expect(services.viewportService.register).toHaveBeenCalledTimes(1);
     });
 
     it("delegates resize and center actions to the viewport service", () => {
-        const renderer = new FanChartRenderer({ ...baseOptions, d3: { select: selectMock } });
+        const services = createServiceBundle();
+        const renderer = createRenderer(services);
 
         renderer.render();
         renderer.resize();
         renderer.resetZoom();
 
-        expect(viewportServiceInstance.resize).toHaveBeenCalledTimes(1);
-        expect(viewportServiceInstance.center).toHaveBeenCalledTimes(1);
+        expect(services.viewportService.resize).toHaveBeenCalledTimes(1);
+        expect(services.viewportService.center).toHaveBeenCalledTimes(1);
     });
 
     it("exports png and svg variants via the configured exporter", () => {
-        const renderer = new FanChartRenderer({ ...baseOptions, d3: { select: selectMock } });
+        const services = createServiceBundle();
+        const renderer = createRenderer(services);
 
         renderer.render();
         renderer.export("png");
         renderer.export("svg");
 
-        expect(renderer._chartExporter.export).toHaveBeenCalledWith("png", renderer._viewLayer.svg);
-        expect(renderer._chartExporter.export).toHaveBeenCalledWith("svg", renderer._viewLayer.svg);
+        expect(services.chartExporter.export).toHaveBeenCalledWith("png", services.viewLayer.svg);
+        expect(services.chartExporter.export).toHaveBeenCalledWith("svg", services.viewLayer.svg);
     });
 
     it("delegates updates through the view layer callback", () => {
-        const renderer = new FanChartRenderer({ ...baseOptions, d3: { select: selectMock } });
+        const services = createServiceBundle();
+        const renderer = createRenderer(services);
 
         renderer.render();
 
-        renderer._viewLayer.updateCallback("/update");
+        services.viewLayer.updateCallback("/update");
 
-        expect(updateConstructor).toHaveBeenCalledWith(renderer._viewLayer.svg, baseOptions.configuration, renderer._layoutEngine, expect.anything());
-        expect(renderer._viewLayer.bindClickEventListener).toHaveBeenCalledTimes(1);
+        expect(updateConstructor).toHaveBeenCalledWith(
+            services.viewLayer.svg,
+            baseOptions.configuration,
+            services.layoutEngine,
+            services.dataLoader,
+        );
+        expect(services.viewLayer.bindClickEventListener).toHaveBeenCalledTimes(1);
         expect(renderer._update.update).toHaveBeenCalledWith("/update", expect.any(Function));
-    });
-
-    it("prefers injected loader, exporters, and viewport services over defaults", () => {
-        const customExportService = { export: jest.fn() };
-        const customDataLoader = { fetchHierarchy: jest.fn() };
-        const customViewportService = { register: jest.fn(), resize: jest.fn(), center: jest.fn() };
-        const renderer = new FanChartRenderer({
-            ...baseOptions,
-            d3: { select: selectMock },
-            chartExporter: customExportService,
-            dataLoader: customDataLoader,
-            viewportService: customViewportService,
-        });
-
-        renderer.render();
-        renderer.export("svg");
-        renderer.update("/custom");
-        renderer.resize();
-        renderer.resetZoom();
-
-        expect(exporterMock).not.toHaveBeenCalled();
-        expect(dataLoaderMock).not.toHaveBeenCalled();
-        expect(customExportService.export).toHaveBeenCalledWith("svg", renderer._viewLayer.svg);
-        expect(updateConstructor).toHaveBeenCalledWith(renderer._viewLayer.svg, baseOptions.configuration, renderer._layoutEngine, customDataLoader);
-        expect(customViewportService.register).toHaveBeenCalledTimes(1);
-        expect(customViewportService.resize).toHaveBeenCalledTimes(1);
-        expect(customViewportService.center).toHaveBeenCalledTimes(1);
-    });
-
-    it("wires update and center callbacks into the viewport service", () => {
-        const renderer = new FanChartRenderer({ ...baseOptions, d3: { select: selectMock } });
-
-        renderer.render();
-
-        viewportOptions.onUpdateViewBox();
-        viewportOptions.onCenter();
-
-        expect(renderer._viewLayer.updateViewBox).toHaveBeenCalledTimes(1);
-        expect(renderer._viewLayer.center).toHaveBeenCalledTimes(1);
     });
 });

--- a/resources/js/tests/modules/index.test.js
+++ b/resources/js/tests/modules/index.test.js
@@ -89,9 +89,6 @@ describe("createFanChart", () => {
 
         const rendererOptions = ctorArgs[0];
 
-        expect(rendererOptions.fanDegree).toBe(300);
-        expect(rendererOptions.fontScale).toBe(125);
-        expect(rendererOptions.innerArcs).toBe(2);
         expect(rendererOptions.configuration.fanDegree).toBe(300);
         expect(rendererOptions.configuration.fontScale).toBe(125);
         expect(rendererOptions.configuration.numberOfInnerCircles).toBe(2);


### PR DESCRIPTION
M# Sweep — Verify compliance for this milestone

- Extracted a default dependency factory for the fan chart renderer services.
- Updated renderer creation to accept pre-built services and documented the dependency bundle types.
- Added focused tests that inject stub services to validate the new structure.

Tests:
- npm test (fails: Playwright browser binaries missing in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924805ceae08323ab82be9aa39dcd31)