### PR TITLE
Fix missing death symbol when death place exists without death date

### DIFF
--- a/src/Facade/DataFacade.php
+++ b/src/Facade/DataFacade.php
@@ -283,7 +283,7 @@ class DataFacade
             }
 
             if ($deathPlace !== '') {
-                $lines[] = $deathPlace;
+                $lines[] = Symbols::SYMBOL_DEATH . ' ' . $deathPlace;
             }
 
             return implode("\n", $lines);


### PR DESCRIPTION
This fixes an inconsistency in appendPlaces().

In the "Birth date only" condition, when a death place exists but no death date is recorded, the death place was appended without the death symbol.

This change adds the missing death symbol so the behavior is consistent with the "No dates" branch.