### PR TITLE
Use bootstrap color variables

### DIFF
--- a/resources/css/fan-chart.css
+++ b/resources/css/fan-chart.css
@@ -125,7 +125,7 @@
 
 .webtrees-fan-chart-container div.overlay .tooltip {
     font-size: 22px;
-    color: #5a6268;
+    color: var(--bs-secondary-color, #5a6268);
     position: relative;
     margin: 0;
     top: 50%;
@@ -209,11 +209,11 @@ div.tooltip {
     height: auto;
     padding: 15px 15px;
     font: 12px sans-serif;
-    background: rgb(240, 240, 240);
-    border: 2px solid rgb(127, 127, 127);
+    background: var(--bs-secondary-bg, rgb(240, 240, 240));
+    border: 2px solid var(--bs-border-color, rgb(127, 127, 127));
     border-radius: 10px;
     pointer-events: none;
-    filter: drop-shadow(0px 0px 5px rgba(0, 0, 0, 0.7));
+    box-shadow: var(--bs-box-shadow-lg, 0 0 5px rgba(0, 0, 0, 0.7));
 }
 
 div.tooltip .image {
@@ -225,8 +225,8 @@ div.tooltip .image {
     height: 100px;
     border-radius: 50%;
     overflow: hidden;
-    background-color: #FFFFFF;
-    filter: drop-shadow(0px 0px 5px rgba(0, 0, 0, 0.7));
+    background-color: var(--bs-body-bg, #ffffff);
+    box-shadow: var(--bs-box-shadow-lg, 0 0 5px rgba(0, 0, 0, 0.7));
 }
 
 div.tooltip .image + .text {
@@ -269,13 +269,13 @@ div.tooltip .name {
 
 div.tooltip .date {
     font-size: 14px;
-    color: rgb(127, 127, 127);
+    color: var(--bs-tertiary-color, rgb(127, 127, 127));
 }
 
 div.tooltip .place td {
     font-size: 12px;
     font-style: italic;
-    color: rgb(127, 127, 127);
+    color: var(--bs-tertiary-color, rgb(127, 127, 127));
     padding-top: 0;
 }
 

--- a/resources/css/fan-chart.css
+++ b/resources/css/fan-chart.css
@@ -264,7 +264,7 @@ div.tooltip .name {
     font-size: 16px;
     margin-right: 10px;
     padding-left: 10px;
-    color: rgb(0, 0, 0);
+    color: var(--bs-body-color, rgb(0, 0, 0));
 }
 
 div.tooltip .date {

--- a/resources/css/fan-chart.css
+++ b/resources/css/fan-chart.css
@@ -209,7 +209,7 @@ div.tooltip {
     height: auto;
     padding: 15px 15px;
     font: 12px sans-serif;
-    background: var(--bs-secondary-bg, rgb(240, 240, 240));
+    background: var(--bs-tertiary-bg, rgb(240, 240, 240));
     border: 2px solid var(--bs-border-color, rgb(127, 127, 127));
     border-radius: 10px;
     pointer-events: none;

--- a/resources/css/svg.css
+++ b/resources/css/svg.css
@@ -16,7 +16,7 @@
 }
 
 .webtrees-fan-chart-container svg g.person g.arc path {
-    fill: var(--bs-tertiary-bg, rgb(235, 235, 235));
+    fill: var(--bs-secondary-bg, rgb(235, 235, 235));
     stroke: none;
 }
 
@@ -26,7 +26,7 @@
 }
 
 .webtrees-fan-chart-container svg g.marriage.empty g.arc path {
-    fill: var(--bs-tertiary-bg, rgb(235, 235, 235));
+    fill: var(--bs-secondary-bg, rgb(235, 235, 235));
 }
 
 .webtrees-fan-chart-container svg g.person.available g.arc path,

--- a/resources/css/svg.css
+++ b/resources/css/svg.css
@@ -16,31 +16,31 @@
 }
 
 .webtrees-fan-chart-container svg g.person g.arc path {
-    fill: rgb(235, 235, 235);
+    fill: var(--bs-tertiary-bg, rgb(235, 235, 235));
     stroke: none;
 }
 
 .webtrees-fan-chart-container svg g.marriage g.arc path {
-    fill: rgb(250, 250, 250);
+    fill: var(--bs-body-bg, rgb(250, 250, 250));
     stroke: none;
 }
 
 .webtrees-fan-chart-container svg g.marriage.empty g.arc path {
-    fill: rgb(235, 235, 235);
+    fill: var(--bs-tertiary-bg, rgb(235, 235, 235));
 }
 
 .webtrees-fan-chart-container svg g.person.available g.arc path,
 .webtrees-fan-chart-container svg g.marriage.available g.arc path {
-    fill: rgb(250, 250, 250);
+    fill: var(--bs-body-bg, rgb(250, 250, 250));
 }
 
 .webtrees-fan-chart-container svg g.separatorGroup line {
-    stroke: rgb(225, 225, 225);
+    stroke: var(--bs-border-color, rgb(225, 225, 225));
     stroke-width: 1px;
 }
 
 .webtrees-fan-chart-container svg g.person.available.hover g.arc path {
-    stroke: rgb(200, 200, 200);
+    stroke: var(--bs-border-color, rgb(200, 200, 200));
     stroke-width: 1.5px;
     filter: brightness(0.95);
 }
@@ -50,14 +50,14 @@
 }
 
 .webtrees-fan-chart-container svg g.name .wt-chart-box-name-alt {
-    fill: rgb(127, 127, 127);
+    fill: var(--bs-tertiary-color, rgb(127, 127, 127));
     font-weight: normal;
     direction: ltr;
     unicode-bidi: normal;
 }
 
 .webtrees-fan-chart-container svg g.name .date {
-    fill: rgb(50, 50, 50);
+    fill: var(--bs-body-color, rgb(50, 50, 50));
     font-size: 85%;
     font-weight: normal;
     direction: ltr;
@@ -65,7 +65,7 @@
 }
 
 .webtrees-fan-chart-container svg g.name .place {
-    fill: rgb(90, 90, 90);
+    fill: var(--bs-secondary-color, rgb(90, 90, 90));
     font-weight: normal;
     font-style: italic;
     direction: ltr;
@@ -77,10 +77,9 @@
 }
 
 .webtrees-fan-chart-container svg .wt-chart-box-name {
-    fill: rgb(50, 50, 50);
+    fill: var(--bs-body-color, rgb(50, 50, 50));
 }
 
 .webtrees-fan-chart-container svg .wt-chart-box-name-alt {
-    fill: rgb(50, 50, 50);
+    fill: var(--bs-body-color, rgb(50, 50, 50));
 }
-


### PR DESCRIPTION
This allows the chart to adapt to the selected theme.

Deliberately not touching button style. Would it be possible to use one of the supplied bootstrap styles of buttons to avoid the custom styling (makes it easier when making themes and trying to get consistent style throughout webtrees)? Maybe outline is closest to the current style.
https://getbootstrap.com/docs/5.3/components/buttons/