### PR TITLE
Gate catalogue freshness locally with a lang-check target and pre-push hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -24,7 +24,7 @@ fi
 staged_po=()
 while IFS= read -r po_file; do
     staged_po+=("$po_file")
-done < <(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.po$' || true)
+done < <(git diff --cached --name-only --diff-filter=ACMR -- '*.po')
 
 if [[ ${#staged_po[@]} -eq 0 ]]; then
     exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -19,22 +19,31 @@ if [[ "${AUDIT_BYPASS:-0}" = "1" ]]; then
 fi
 
 # Identify staged PO files. If none — exit silently, nothing to gate.
-mapfile -t staged_po < <(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.po$' || true)
+# A while-read loop (not mapfile/readarray, which is Bash 4.0+) keeps the hook
+# working on the Bash 3.2 that macOS still ships as /bin/bash.
+staged_po=()
+while IFS= read -r po_file; do
+    staged_po+=("$po_file")
+done < <(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.po$' || true)
+
 if [[ ${#staged_po[@]} -eq 0 ]]; then
     exit 0
 fi
 
-# Count fuzzy entries inside each staged PO. Active fuzzy is a comment
-# line starting with `#,` whose flag list mentions `fuzzy`. Skip
-# obsolete blocks (prefixed `#~`). Avoid awk `\b` because busybox /
-# mawk variants don't grok the word-boundary escape.
+# Count fuzzy entries inside each staged PO. Read the STAGED blob
+# (`git show :path`), not the working-tree file — a partial commit (`git add
+# -p`) can stage a clean PO while the working tree still carries fuzzy entries
+# (or vice versa), and the index is what actually gets committed. Active fuzzy
+# is a comment line starting with `#,` whose flag list mentions `fuzzy`; skip
+# obsolete blocks (prefixed `#~`). Avoid awk `\b` because busybox / mawk
+# variants don't grok the word-boundary escape.
 declare -a offenders=()
 for po in "${staged_po[@]}"; do
-    fuzzy_count=$(awk '
+    fuzzy_count=$(git show ":$po" | awk '
         /^#~/         { next }
         /^#,.*fuzzy/  { c++ }
         END           { print c+0 }
-    ' "$po")
+    ')
 
     if [[ "$fuzzy_count" -gt 0 ]]; then
         offenders+=("  ${po}: ${fuzzy_count} fuzzy entries")

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Block commits that introduce or leave fuzzy translation entries in any PO
+# file. msgfmt drops fuzzy entries from the compiled MO, so a committed
+# fuzzy entry silently ships as the English fallback for that locale.
+#
+# Resolution path on a block:
+#   1) `make lang-resolve-fuzzy` — auto-fixes punctuation-only drift.
+#   2) If anything stays fuzzy, edit the msgstr by hand (or the dev/i18n
+#      JSON catalogue) and re-run `make lang` to recompile.
+#   3) Override for a deliberate hand-off: `AUDIT_BYPASS=1 git commit …`.
+#
+# The hook only runs when a PO file is part of the staged change set, so
+# commits that don't touch translations skip the scan entirely.
+
+set -euo pipefail
+
+if [[ "${AUDIT_BYPASS:-0}" = "1" ]]; then
+    exit 0
+fi
+
+# Identify staged PO files. If none — exit silently, nothing to gate.
+mapfile -t staged_po < <(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.po$' || true)
+if [[ ${#staged_po[@]} -eq 0 ]]; then
+    exit 0
+fi
+
+# Count fuzzy entries inside each staged PO. Active fuzzy is a comment
+# line starting with `#,` whose flag list mentions `fuzzy`. Skip
+# obsolete blocks (prefixed `#~`). Avoid awk `\b` because busybox /
+# mawk variants don't grok the word-boundary escape.
+declare -a offenders=()
+for po in "${staged_po[@]}"; do
+    fuzzy_count=$(awk '
+        /^#~/         { next }
+        /^#,.*fuzzy/  { c++ }
+        END           { print c+0 }
+    ' "$po")
+
+    if [[ "$fuzzy_count" -gt 0 ]]; then
+        offenders+=("  ${po}: ${fuzzy_count} fuzzy entries")
+    fi
+done
+
+if [[ ${#offenders[@]} -eq 0 ]]; then
+    exit 0
+fi
+
+echo
+echo "✘ pre-commit: PO files contain fuzzy entries that will be dropped from the MO."
+echo
+printf '%s\n' "${offenders[@]}"
+echo
+echo "Resolve via:"
+echo "    make lang-resolve-fuzzy   # punctuation-only drift is auto-fixed"
+echo "    make lang                 # full extract → merge → resolve → compile"
+echo
+echo "Or stage explicit translations, then re-commit."
+echo "Bypass once with AUDIT_BYPASS=1 git commit …"
+echo
+exit 1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Block a push whose committed translation catalogue is stale. Any line shift
+# in a file carrying I18N::translate() drifts the catalogue's `#:` source
+# references, which the GitHub `catalogue / Pipeline freshness` job then fails —
+# a class of red that has bitten more than once because nothing caught it
+# locally. This hook mirrors that gate before the push: `make lang-check`
+# regenerates the catalogue (in the project's node container, so the gettext
+# version matches CI) and fails if the working tree changed.
+#
+# Resolution path on a block:
+#   make lang && git add resources/lang && git commit  # then push again
+#
+# Bypass once for a deliberate hand-off: AUDIT_BYPASS=1 git push …
+
+set -euo pipefail
+
+if [[ "${AUDIT_BYPASS:-0}" = "1" ]]; then
+    exit 0
+fi
+
+# Only repositories with a translation pipeline have anything to check.
+if [[ ! -d resources/lang ]]; then
+    exit 0
+fi
+
+exec make lang-check

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -23,4 +23,20 @@ if [[ ! -d resources/lang ]]; then
     exit 0
 fi
 
+# A pre-push hook receives the ref updates on stdin as
+# "<local-ref> <local-sha> <remote-ref> <remote-sha>" lines. Skip the check when
+# every pushed ref is a deletion (local sha is the all-zero oid) — a branch
+# deletion adds nothing whose line shift could drift the catalogue, and the node
+# container is needless overhead there.
+has_update=0
+while read -r _local_ref local_sha _remote_ref _remote_sha; do
+    if [[ ! "$local_sha" =~ ^0+$ ]]; then
+        has_update=1
+    fi
+done
+
+if [[ "$has_update" -eq 0 ]]; then
+    exit 0
+fi
+
 exec make lang-check

--- a/Make/lang.mk
+++ b/Make/lang.mk
@@ -4,7 +4,7 @@
 
 #### Language & Translations
 
-.PHONY: lang lang-extract lang-merge lang-resolve-fuzzy lang-compile
+.PHONY: lang lang-check setup-hooks lang-extract lang-merge lang-resolve-fuzzy lang-compile
 
 # Locales the module ships translations for. Auto-discovered from the
 # existing per-locale directories rather than a hardcoded list — a
@@ -87,3 +87,15 @@ lang-compile: ## Compile every messages.po to its sibling messages.mo.
 			msgfmt -o "$$dir/messages.mo" "$$po" && \
 				echo "  ✔ Compiled $$po"; \
 		done'
+
+setup-hooks: ## Activate the tracked .githooks/ directory for this clone.
+	@git config core.hooksPath .githooks && \
+		echo "  ✔ core.hooksPath = .githooks (pre-commit gate active)"
+
+lang-check: lang ## Fail if the committed catalogue is stale (local mirror of the CI Pipeline-freshness gate); the pre-push hook runs this.
+	@if [ -n "$$(git status --porcelain -- resources/lang)" ]; then \
+		echo "  ✘ catalogue stale — run 'make lang' and commit the result:"; \
+		git status --porcelain -- resources/lang; \
+		exit 1; \
+	fi; \
+	echo "  ✔ catalogue fresh — make lang is a no-op"


### PR DESCRIPTION
## What

Mirror the i18n hook infrastructure already used by `webtrees-statistics` so a stale translation catalogue is caught **locally before the push** instead of going red on the GitHub `catalogue / Pipeline freshness` job.

## Why

Any line shift in a file carrying `I18N::translate()` drifts the catalogue's `#:` source references (not just adding/removing strings). The GitHub freshness job catches it, but only **after** the push — and `make lang` needs the host (it orchestrates the node container), so it cannot live in the container-bound `composer ci:test`. A pre-push hook is the right place.

## Changes

- `.githooks/pre-commit` — blocks committing fuzzy PO entries (they would otherwise ship as the English fallback).
- `.githooks/pre-push` — runs `make lang-check` when `resources/lang` exists; `AUDIT_BYPASS=1 git push` bypasses it.
- `Make/lang.mk` — `lang-check` target (runs `make lang`, fails if the working tree changed) + `setup-hooks` target.

## One-time activation

`make setup-hooks` per clone points `core.hooksPath` at `.githooks` (the hooks are inert until then).
