### PR TITLE
Migrate the copy-paste-detection setup to jscpd 5.x

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,20 +1,20 @@
 {
-    "languages": [
+    "format": [
         "php",
         "javascript"
     ],
     "threshold": 0,
     "reporters": [
-        "consoleFull"
+        "console-full"
     ],
     "minTokens": 100,
     "minLines": 5,
     "path": [
-        "src/",
-        "resources/js/modules/"
+        "src",
+        "resources/js/modules"
     ],
     "ignore": [
         "**/*.min.js"
     ],
-    "exitCode": true
+    "exitCode": 1
 }

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
             "@ci:rector --dry-run"
         ],
         "ci:test:cpd": [
-            "npx jscpd src resources/js/modules --config .jscpd.json"
+            "npx jscpd src resources/js/modules --config .jscpd.json --skip-comments --no-tips"
         ],
         "ci:test:php:unit": [
             "phpunit --configuration phpunit.xml --display-all-issues"

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "d3-zoom": "^3.0",
                 "jest": "^30.4",
                 "jest-environment-jsdom": "^30.4",
-                "jscpd": "^4.2.4",
+                "jscpd": "^5.0.9",
                 "pixelmatch": "^7.0",
                 "playwright": "^1.60",
                 "pngjs": "^7.0",
@@ -725,15 +725,6 @@
                 "node": ">=14.21.3"
             }
         },
-        "node_modules/@colors/colors": {
-            "version": "1.5.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=0.1.90"
-            }
-        },
         "node_modules/@csstools/color-helpers": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -1346,60 +1337,6 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
-        "node_modules/@jscpd/badge-reporter": {
-            "version": "4.2.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "badgen": "^3.2.3",
-                "colors": "^1.4.0",
-                "fs-extra": "^11.2.0"
-            }
-        },
-        "node_modules/@jscpd/core": {
-            "version": "4.2.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "eventemitter3": "^5.0.1"
-            }
-        },
-        "node_modules/@jscpd/finder": {
-            "version": "4.2.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jscpd/core": "4.2.4",
-                "@jscpd/tokenizer": "4.2.4",
-                "blamer": "^1.0.6",
-                "bytes": "^3.1.2",
-                "cli-table3": "^0.6.5",
-                "colors": "^1.4.0",
-                "fast-glob": "^3.3.2",
-                "fs-extra": "^11.2.0",
-                "markdown-table": "^2.0.0",
-                "pug": "^3.0.3"
-            }
-        },
-        "node_modules/@jscpd/html-reporter": {
-            "version": "4.2.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "colors": "1.4.0",
-                "fs-extra": "^11.2.0",
-                "pug": "^3.0.3"
-            }
-        },
-        "node_modules/@jscpd/tokenizer": {
-            "version": "4.2.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jscpd/core": "4.2.4",
-                "spark-md5": "^3.0.2"
-            }
-        },
         "node_modules/@magicsunday/webtrees-chart-lib": {
             "version": "1.14.0",
             "resolved": "git+ssh://git@github.com/magicsunday/webtrees-chart-lib.git#3f5235a6da125316704bfd5d5de62fc25f23723d",
@@ -1441,38 +1378,6 @@
             "peerDependencies": {
                 "@emnapi/core": "^1.7.1",
                 "@emnapi/runtime": "^1.7.1"
-            }
-        },
-        "node_modules/@nodelib/fs.scandir": {
-            "version": "2.1.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.stat": "2.0.5",
-                "run-parallel": "^1.1.9"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.stat": {
-            "version": "2.0.5",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.walk": {
-            "version": "1.2.8",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.scandir": "2.1.5",
-                "fastq": "^1.6.0"
-            },
-            "engines": {
-                "node": ">= 8"
             }
         },
         "node_modules/@pkgjs/parseargs": {
@@ -2139,11 +2044,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/sarif": {
-            "version": "2.1.7",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/stack-utils": {
             "version": "2.0.3",
             "dev": true,
@@ -2489,17 +2389,6 @@
                 "win32"
             ]
         },
-        "node_modules/acorn": {
-            "version": "7.4.1",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/agent-base": {
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2597,16 +2486,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/asap": {
-            "version": "2.0.6",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/assert-never": {
-            "version": "1.4.0",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/babel-jest": {
             "version": "30.4.1",
@@ -2707,22 +2586,6 @@
                 "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
             }
         },
-        "node_modules/babel-walk": {
-            "version": "3.0.0-canary-5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.9.6"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/badgen": {
-            "version": "3.3.2",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2743,67 +2606,6 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/blamer": {
-            "version": "1.0.7",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "execa": "^4.0.0",
-                "which": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=8.9"
-            }
-        },
-        "node_modules/blamer/node_modules/execa": {
-            "version": "4.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^7.0.0",
-                "get-stream": "^5.0.0",
-                "human-signals": "^1.1.1",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.0",
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/blamer/node_modules/get-stream": {
-            "version": "5.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "pump": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/blamer/node_modules/human-signals": {
-            "version": "1.1.1",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=8.12.0"
-            }
-        },
-        "node_modules/blamer/node_modules/signal-exit": {
-            "version": "3.0.7",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/brace-expansion": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
@@ -2812,17 +2614,6 @@
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/braces": {
-            "version": "3.0.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fill-range": "^7.1.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/browserslist": {
@@ -2873,41 +2664,6 @@
             "version": "1.1.2",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/bytes": {
-            "version": "3.1.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/call-bind-apply-helpers": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/call-bound": {
-            "version": "1.0.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "get-intrinsic": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/callsites": {
             "version": "3.1.0",
@@ -2975,14 +2731,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/character-parser": {
-            "version": "2.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-regex": "^1.0.3"
-            }
-        },
         "node_modules/ci-info": {
             "version": "4.4.0",
             "dev": true,
@@ -3003,57 +2751,6 @@
             "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/cli-table3": {
-            "version": "0.6.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "string-width": "^4.2.0"
-            },
-            "engines": {
-                "node": "10.* || >= 12.*"
-            },
-            "optionalDependencies": {
-                "@colors/colors": "1.5.0"
-            }
-        },
-        "node_modules/cli-table3/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cli-table3/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/cli-table3/node_modules/string-width": {
-            "version": "4.2.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cli-table3/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/cliui": {
             "version": "8.0.1",
@@ -3167,14 +2864,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/colors": {
-            "version": "1.4.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.1.90"
-            }
-        },
         "node_modules/commander": {
             "version": "7.2.0",
             "dev": true,
@@ -3195,21 +2884,105 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/constantinople": {
-            "version": "4.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.6.0",
-                "@babel/types": "^7.6.1"
-            }
-        },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/cpd-darwin-arm64": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/cpd-darwin-arm64/-/cpd-darwin-arm64-5.0.9.tgz",
+            "integrity": "sha512-hUYQKrUUmlYxl2MDD8GYESpcKc5M5eGMjiHTK+O8ooCj1ogPiNHXg+aIeDl6BuLu7v3jFDcCu5fVqtcpHzAKpw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/cpd-darwin-x64": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/cpd-darwin-x64/-/cpd-darwin-x64-5.0.9.tgz",
+            "integrity": "sha512-viCFEUhUQnGundSMFq9ixi+RxfRiNDQsWP/CZErMlf20fM5h9zTtrHI9liNyRQn+ZtQUTTpabQ4PpzDV530bMg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/cpd-linux-arm64-gnu": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/cpd-linux-arm64-gnu/-/cpd-linux-arm64-gnu-5.0.9.tgz",
+            "integrity": "sha512-BxiLx9haM+AhDlkyFoe1ro1w4/dvAteyEGytv4XraaRNntw2NMFX1Fsa9I8waegpXydM6E0lPWRWqkG59rin3A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/cpd-linux-x64-gnu": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/cpd-linux-x64-gnu/-/cpd-linux-x64-gnu-5.0.9.tgz",
+            "integrity": "sha512-VC2bUEJ0KRZ3fJijqqFcrBl6a69vmHrrNoJkSPtFwFju8x7ce2Vs9ntEmlxeB7Ho4mIzN8OYOrlCeqyNdAZcUA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/cpd-linux-x64-musl": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/cpd-linux-x64-musl/-/cpd-linux-x64-musl-5.0.9.tgz",
+            "integrity": "sha512-YJekKRRgAhez2+Rrbt42fp8cJuNi/PtGuBb8jIzEtegXRRBG9CE9HaoTy0mS3JeiQuwxiT0Fnz2j8hR9gDbq0w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/cpd-windows-x64-msvc": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/cpd-windows-x64-msvc/-/cpd-windows-x64-msvc-5.0.9.tgz",
+            "integrity": "sha512-Z54yLFmRjIgTMqzeUxbZzgxj8gWxB/jjMi/QOkBOLx9yHHwzhW8MukpY7JhCOmlvPOOn6pjSVrMTxChliDcYAw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -3597,24 +3370,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/doctypes": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/dunder-proto": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.2.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -3649,14 +3404,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/end-of-stream": {
-            "version": "1.4.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "once": "^1.4.0"
-            }
-        },
         "node_modules/entities": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -3680,29 +3427,10 @@
                 "is-arrayish": "^0.2.1"
             }
         },
-        "node_modules/es-define-property": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/es-errors": {
             "version": "1.3.0",
             "dev": true,
             "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-object-atoms": {
-            "version": "1.1.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0"
-            },
             "engines": {
                 "node": ">= 0.4"
             }
@@ -3741,11 +3469,6 @@
         },
         "node_modules/estree-walker": {
             "version": "2.0.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/eventemitter3": {
-            "version": "5.0.4",
             "dev": true,
             "license": "MIT"
         },
@@ -3808,35 +3531,12 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/fast-glob": {
-            "version": "3.3.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.8"
-            },
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/fastq": {
-            "version": "1.20.1",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "reusify": "^1.0.4"
-            }
         },
         "node_modules/fb-watchman": {
             "version": "2.0.2",
@@ -3862,17 +3562,6 @@
                 "picomatch": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/fill-range": {
-            "version": "7.1.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "to-regex-range": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/find-up": {
@@ -3904,19 +3593,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/fs-extra": {
-            "version": "11.3.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.14"
             }
         },
         "node_modules/fs.realpath": {
@@ -3969,29 +3645,6 @@
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
-        "node_modules/get-intrinsic": {
-            "version": "1.3.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "es-define-property": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.1.1",
-                "function-bind": "^1.1.2",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "has-symbols": "^1.1.0",
-                "hasown": "^2.0.2",
-                "math-intrinsics": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/get-package-type": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -4000,18 +3653,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8.0.0"
-            }
-        },
-        "node_modules/get-proto": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "dunder-proto": "^1.0.1",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/get-stream": {
@@ -4049,28 +3690,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/glob-parent": {
-            "version": "5.1.2",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/gopd": {
-            "version": "1.2.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "dev": true,
@@ -4082,31 +3701,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/has-symbols": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-tostringtag": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-symbols": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/hasown": {
@@ -4266,23 +3860,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-expression": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^7.1.1",
-                "object-assign": "^4.1.1"
-            }
-        },
-        "node_modules/is-extglob": {
-            "version": "2.1.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "dev": true,
@@ -4301,29 +3878,10 @@
                 "node": ">=6"
             }
         },
-        "node_modules/is-glob": {
-            "version": "4.0.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-extglob": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-module": {
             "version": "1.0.0",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/is-number": {
-            "version": "7.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.12.0"
-            }
         },
         "node_modules/is-potential-custom-element-name": {
             "version": "1.0.1",
@@ -4331,28 +3889,6 @@
             "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/is-promise": {
-            "version": "2.2.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/is-regex": {
-            "version": "1.2.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "gopd": "^1.2.0",
-                "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/is-stream": {
             "version": "2.0.1",
@@ -5086,11 +4622,6 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
-        "node_modules/js-stringify": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "dev": true,
@@ -5111,42 +4642,25 @@
             }
         },
         "node_modules/jscpd": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-4.2.4.tgz",
-            "integrity": "sha512-PSo2U0G8OxULayGyQMv7T/0ZQ+c3PPltdMOz/57v9Xnmq5xSIhh4cnZ0oYZPKqejy10aFwAbMVxqAlo24+PQ3g==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-5.0.9.tgz",
+            "integrity": "sha512-52zn0erBrRCCLvKulOs/UNUsL2fAmnMRUUbwbJhfUmqI9jtVSQ2Hk20F7m58JnkmgBEoyNBSTTomrF8K+H4fLA==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "@jscpd/badge-reporter": "4.2.4",
-                "@jscpd/core": "4.2.4",
-                "@jscpd/finder": "4.2.4",
-                "@jscpd/html-reporter": "4.2.4",
-                "@jscpd/tokenizer": "4.2.4",
-                "colors": "^1.4.0",
-                "commander": "^5.0.0",
-                "fs-extra": "^11.2.0",
-                "jscpd-sarif-reporter": "4.2.4"
-            },
             "bin": {
-                "jscpd": "bin/jscpd"
-            }
-        },
-        "node_modules/jscpd-sarif-reporter": {
-            "version": "4.2.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "colors": "^1.4.0",
-                "fs-extra": "^11.2.0",
-                "node-sarif-builder": "^3.4.0"
-            }
-        },
-        "node_modules/jscpd/node_modules/commander": {
-            "version": "5.1.0",
-            "dev": true,
-            "license": "MIT",
+                "cpd": "run-jscpd.js",
+                "jscpd": "run-jscpd.js"
+            },
             "engines": {
-                "node": ">= 6"
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "cpd-darwin-arm64": "5.0.9",
+                "cpd-darwin-x64": "5.0.9",
+                "cpd-linux-arm64-gnu": "5.0.9",
+                "cpd-linux-x64-gnu": "5.0.9",
+                "cpd-linux-x64-musl": "5.0.9",
+                "cpd-windows-x64-msvc": "5.0.9"
             }
         },
         "node_modules/jsdom": {
@@ -5220,26 +4734,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/jsonfile": {
-            "version": "6.2.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/jstransformer": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-promise": "^2.0.0",
-                "promise": "^7.0.1"
             }
         },
         "node_modules/leven": {
@@ -5334,61 +4828,10 @@
                 "tmpl": "1.0.5"
             }
         },
-        "node_modules/markdown-table": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "repeat-string": "^1.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/math-intrinsics": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/merge2": {
-            "version": "1.4.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/micromatch": {
-            "version": "4.0.8",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "braces": "^3.0.3",
-                "picomatch": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.6"
-            }
-        },
-        "node_modules/micromatch/node_modules/picomatch": {
-            "version": "2.3.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
         },
         "node_modules/mimic-fn": {
             "version": "2.1.0",
@@ -5477,18 +4920,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/node-sarif-builder": {
-            "version": "3.4.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/sarif": "^2.1.7",
-                "fs-extra": "^11.1.1"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -5516,14 +4947,6 @@
             "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/object-assign": {
-            "version": "4.1.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/once": {
             "version": "1.4.0",
@@ -5841,135 +5264,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/promise": {
-            "version": "7.3.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "asap": "~2.0.3"
-            }
-        },
-        "node_modules/pug": {
-            "version": "3.0.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "pug-code-gen": "^3.0.4",
-                "pug-filters": "^4.0.0",
-                "pug-lexer": "^5.0.1",
-                "pug-linker": "^4.0.0",
-                "pug-load": "^3.0.0",
-                "pug-parser": "^6.0.0",
-                "pug-runtime": "^3.0.1",
-                "pug-strip-comments": "^2.0.0"
-            }
-        },
-        "node_modules/pug-attrs": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "constantinople": "^4.0.1",
-                "js-stringify": "^1.0.2",
-                "pug-runtime": "^3.0.0"
-            }
-        },
-        "node_modules/pug-code-gen": {
-            "version": "3.0.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "constantinople": "^4.0.1",
-                "doctypes": "^1.1.0",
-                "js-stringify": "^1.0.2",
-                "pug-attrs": "^3.0.0",
-                "pug-error": "^2.1.0",
-                "pug-runtime": "^3.0.1",
-                "void-elements": "^3.1.0",
-                "with": "^7.0.0"
-            }
-        },
-        "node_modules/pug-error": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/pug-filters": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "constantinople": "^4.0.1",
-                "jstransformer": "1.0.0",
-                "pug-error": "^2.0.0",
-                "pug-walk": "^2.0.0",
-                "resolve": "^1.15.1"
-            }
-        },
-        "node_modules/pug-lexer": {
-            "version": "5.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "character-parser": "^2.2.0",
-                "is-expression": "^4.0.0",
-                "pug-error": "^2.0.0"
-            }
-        },
-        "node_modules/pug-linker": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "pug-error": "^2.0.0",
-                "pug-walk": "^2.0.0"
-            }
-        },
-        "node_modules/pug-load": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "object-assign": "^4.1.1",
-                "pug-walk": "^2.0.0"
-            }
-        },
-        "node_modules/pug-parser": {
-            "version": "6.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "pug-error": "^2.0.0",
-                "token-stream": "1.0.0"
-            }
-        },
-        "node_modules/pug-runtime": {
-            "version": "3.0.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/pug-strip-comments": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "pug-error": "^2.0.0"
-            }
-        },
-        "node_modules/pug-walk": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/pump": {
-            "version": "3.0.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5997,25 +5291,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/queue-microtask": {
-            "version": "1.2.3",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/react-is-18": {
             "name": "react-is",
             "version": "18.3.1",
@@ -6031,14 +5306,6 @@
             "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/repeat-string": {
-            "version": "1.6.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10"
-            }
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
@@ -6091,15 +5358,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/reusify": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "iojs": ">=1.0.0",
-                "node": ">=0.10.0"
             }
         },
         "node_modules/rollup": {
@@ -6174,28 +5432,6 @@
             "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/run-parallel": {
-            "version": "1.2.0",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "queue-microtask": "^1.2.2"
-            }
         },
         "node_modules/rw": {
             "version": "1.3.3",
@@ -6304,11 +5540,6 @@
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
             }
-        },
-        "node_modules/spark-md5": {
-            "version": "3.0.2",
-            "dev": true,
-            "license": "(WTFPL OR MIT)"
         },
         "node_modules/spdx-compare": {
             "version": "1.0.0",
@@ -6727,22 +5958,6 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
-        "node_modules/to-regex-range": {
-            "version": "5.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-number": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=8.0"
-            }
-        },
-        "node_modules/token-stream": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/tough-cookie": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -6814,14 +6029,6 @@
             "version": "7.19.2",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/universalify": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10.0.0"
-            }
         },
         "node_modules/unrs-resolver": {
             "version": "1.12.2",
@@ -6907,14 +6114,6 @@
                 "node": ">=10.12.0"
             }
         },
-        "node_modules/void-elements": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/w3c-xmlserializer": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -6998,20 +6197,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/with": {
-            "version": "7.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.9.6",
-                "@babel/types": "^7.9.6",
-                "assert-never": "^1.2.1",
-                "babel-walk": "3.0.0-canary-5"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
             }
         },
         "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "d3-zoom": "^3.0",
         "jest": "^30.4",
         "jest-environment-jsdom": "^30.4",
-        "jscpd": "^4.2.4",
+        "jscpd": "^5.0.9",
         "pixelmatch": "^7.0",
         "playwright": "^1.60",
         "pngjs": "^7.0",


### PR DESCRIPTION
## Summary

jscpd 5 (a Rust rewrite) is the current major; this migrates the copy-paste-detection setup off the 4.x line. A config-only migration — no real clones surfaced.

- `.jscpd.json` to the 5.x schema: `languages`→`format`, `consoleFull`→`console-full`, `exitCode` `true`→`1`, trailing path slashes dropped.
- `ci:test:cpd` gains `--skip-comments` (jscpd 4 skipped comment tokens by default; v5 counts them, so the shared license/class docblock would register as a clone) and `--no-tips`.
- Bump jscpd to `^5.0.9` (5.0.6 restored reading the config's detection knobs that 5.0.4 ignored). The lockfile shrinks sharply because the v4 JS dep-tree is replaced by the v5 Rust binary.

## Verification
`composer ci:test` green — jscpd reports 0 clones, and the step still exits non-zero on a real duplicate.