### PR TITLE
Pin the Node toolchain to node:24-alpine (kill bundle-freshness phantom-diffs)

### DIFF
--- a/.github/workflows/bundle-freshness.yml
+++ b/.github/workflows/bundle-freshness.yml
@@ -12,3 +12,5 @@ jobs:
         uses: magicsunday/.github/.github/workflows/bundle-freshness.yml@main
         permissions:
             contents: read
+        with:
+            node-image: node:24-alpine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
               name: Set up Node.js
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: npm
 
             - id: setup_php

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -15,3 +15,4 @@ jobs:
             contents: read
         with:
             check-pipeline: true
+            node-image: node:24-alpine

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
     node:
-        image: node:lts-alpine
+        image: node:24-alpine
         working_dir: /app
         volumes:
             - ./:/app


### PR DESCRIPTION
Pin the Node toolchain to `node:24-alpine` across this chart-lib consumer: the local `compose.yaml` `node` service, the `setup-node` step in `ci.yml` (22 → 24), and the reusable `bundle-freshness` and `i18n` callers (via `node-image: node:24-alpine`). This stops bundle-freshness phantom-diffs caused by the floating `node:lts-alpine` / `node 22` Node major drifting from the committed bundle's build environment.

The committed `resources/js/*.min.js` bundle was rebuilt in `node:24-alpine` and is unchanged.

Part of magicsunday/.github#7.