### PR TITLE
Correct the documented commit convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,11 @@ Pipeline (`make release X.Y.Z`):
 
 ## PR/commit checklist
 - `composer ci:test` must pass before every commit.
-- Use Conventional Commits; include ticket IDs in titles when available (e.g. `Fixes #182`).
+- Commit subjects match `^(GH-<N>: )?[A-ZÄÖÜ]` — a capitalised imperative, with the
+  `GH-<N>: ` prefix on issue-tied work. **No conventional-commit prefixes**
+  (`feat:`, `fix:`, `chore:` …), no lowercase or path-like starts. Branches for an
+  issue are named exactly `GH-<N>`.
+- Never add a `Co-Authored-By:` trailer or any other AI attribution.
 - Keep PRs small and focused (~≤300 net LOC) with atomic commits.
 - Ensure coverage ≥90% on touched PHP paths.
 - After PR receives review comments: assess, fix, commit, reply with commit hash, resolve threads via GraphQL.


### PR DESCRIPTION
`AGENTS.md` prescribed Conventional Commits. This repository has never used them.

Of the last 60 commits: **0** carry a conventional prefix, **60** start with a capitalised imperative (`Release 3.7.1`, `Add missing Dutch translation …`, `Bump version to 3.7.2-dev`). An agent following the documented rule would have produced the one format the repository does not use — and the rule was copied unchanged into two sibling modules, so the error propagated.

Replaced with the convention actually in force:

- subjects match `^(GH-<N>: )?[A-ZÄÖÜ]` — capitalised imperative, `GH-<N>: ` prefix for issue-tied work;
- no conventional-commit prefixes, no lowercase or path-like starts;
- issue branches named exactly `GH-<N>`;
- no `Co-Authored-By:` trailer or other AI attribution.

Documentation only — no code, no tests, no CI surface touched. The same correction is going to the pedigree-chart and descendants-chart modules, which carry the identical line.