### PR TITLE
Make the documented commit-subject pattern a valid regex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,10 +126,12 @@ Pipeline (`make release X.Y.Z`):
 - Commit subjects match `^GH-\d+: [A-ZÄÖÜ]` on issue-tied work and `^[A-ZÄÖÜ]`
   otherwise — a capitalised imperative either way. **No conventional-commit prefixes**
   (`feat:`, `fix:`, `chore:` …), no lowercase and no path-like starts
-  (`src/Module.php: …`). Branches for an issue are named exactly `GH-<N>`.
-    - Keep the two patterns separate. Folded into `^(GH-\d+: )?[A-ZÄÖÜ]` the rule
-      stops enforcing the capital *after* the prefix: the optional group can be
-      skipped, and the `G` of `GH-` then satisfies `[A-ZÄÖÜ]` on its own.
+  (`src/Module.php: …`). Branches for an issue are named exactly `GH-<N>`, where
+  `<N>` is the issue number.
+    - The two patterns are deliberately kept separate. Folded into
+      `^(GH-\d+: )?[A-ZÄÖÜ]` the rule stops enforcing the capital *after* the
+      prefix: the optional group can be skipped, and the `G` of `GH-` then
+      satisfies `[A-ZÄÖÜ]` on its own.
 - Never add a `Co-Authored-By:` trailer or any other AI attribution.
 - Keep PRs small and focused (~≤300 net LOC) with atomic commits.
 - Ensure coverage ≥90% on touched PHP paths.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,13 +123,13 @@ Pipeline (`make release X.Y.Z`):
 
 ## PR/commit checklist
 - `composer ci:test` must pass before every commit.
-- Commit subjects match `^GH-\d+: [A-ZÄÖÜ]` on issue-tied work (`<N>` being the issue
-  number) and `^[A-ZÄÖÜ]` otherwise — a capitalised imperative either way. The two
-  cases are stated separately on purpose: folded into `^(GH-\d+: )?[A-ZÄÖÜ]` the rule
-  enforces nothing for a prefixed subject, because the optional group can be skipped
-  and the `G` of `GH-` then satisfies `[A-ZÄÖÜ]`. **No conventional-commit prefixes**
-  (`feat:`, `fix:`, `chore:` …), no lowercase or path-like starts. Branches for an
-  issue are named exactly `GH-<N>`.
+- Commit subjects match `^GH-\d+: [A-ZÄÖÜ]` on issue-tied work and `^[A-ZÄÖÜ]`
+  otherwise — a capitalised imperative either way. **No conventional-commit prefixes**
+  (`feat:`, `fix:`, `chore:` …), no lowercase and no path-like starts
+  (`src/Module.php: …`). Branches for an issue are named exactly `GH-<N>`.
+    - Keep the two patterns separate. Folded into `^(GH-\d+: )?[A-ZÄÖÜ]` the rule
+      stops enforcing the capital *after* the prefix: the optional group can be
+      skipped, and the `G` of `GH-` then satisfies `[A-ZÄÖÜ]` on its own.
 - Never add a `Co-Authored-By:` trailer or any other AI attribution.
 - Keep PRs small and focused (~≤300 net LOC) with atomic commits.
 - Ensure coverage ≥90% on touched PHP paths.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,12 +126,12 @@ Pipeline (`make release X.Y.Z`):
 - Commit subjects match `^GH-\d+: [A-ZÄÖÜ]` on issue-tied work and `^[A-ZÄÖÜ]`
   otherwise — a capitalised imperative either way. **No conventional-commit prefixes**
   (`feat:`, `fix:`, `chore:` …), no lowercase and no path-like starts
-  (`src/Module.php: …`). Branches for an issue are named exactly `GH-<N>`, where
-  `<N>` is the issue number.
+  (`src/Module.php: …`).
     - The two patterns are deliberately kept separate. Folded into
       `^(GH-\d+: )?[A-ZÄÖÜ]` the rule stops enforcing the capital *after* the
       prefix: the optional group can be skipped, and the `G` of `GH-` then
-      satisfies `[A-ZÄÖÜ]` on its own.
+      satisfies `[A-ZÄÖÜ]` on its own — `GH-12: fix typo` would pass.
+- Branches for an issue are named exactly `GH-<N>`, where `<N>` is the issue number.
 - Never add a `Co-Authored-By:` trailer or any other AI attribution.
 - Keep PRs small and focused (~≤300 net LOC) with atomic commits.
 - Ensure coverage ≥90% on touched PHP paths.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,8 +123,11 @@ Pipeline (`make release X.Y.Z`):
 
 ## PR/commit checklist
 - `composer ci:test` must pass before every commit.
-- Commit subjects match `^(GH-\d+: )?[A-ZÄÖÜ]` — a capitalised imperative, with the
-  `GH-<N>: ` prefix (`<N>` being the issue number) on issue-tied work. **No conventional-commit prefixes**
+- Commit subjects match `^GH-\d+: [A-ZÄÖÜ]` on issue-tied work (`<N>` being the issue
+  number) and `^[A-ZÄÖÜ]` otherwise — a capitalised imperative either way. The two
+  cases are stated separately on purpose: folded into `^(GH-\d+: )?[A-ZÄÖÜ]` the rule
+  enforces nothing for a prefixed subject, because the optional group can be skipped
+  and the `G` of `GH-` then satisfies `[A-ZÄÖÜ]`. **No conventional-commit prefixes**
   (`feat:`, `fix:`, `chore:` …), no lowercase or path-like starts. Branches for an
   issue are named exactly `GH-<N>`.
 - Never add a `Co-Authored-By:` trailer or any other AI attribution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,16 +126,16 @@ Pipeline (`make release X.Y.Z`):
 - A subject starting with `GH-` must match `^GH-\d+: [A-ZÄÖÜ]`; every other subject
   must match `^[A-ZÄÖÜ]` — a capitalised imperative either way. **No
   conventional-commit prefixes** (`feat:`, `fix:`, `chore:` …), no lowercase and no
-  path-like starts (`src/Module.php: …`). Tool-generated subjects (`Merge …`,
-  `Revert "…"`) are exempt.
+  path-like starts (`src/Module.php: …`).
     - The two patterns are deliberately kept separate: `^(GH-\d+: )?[A-ZÄÖÜ]` (wrong)
       stops enforcing the capital *after* the prefix, because the optional group can
       be skipped and the `G` of `GH-` then satisfies `[A-ZÄÖÜ]` on its own —
       `GH-12: fix typo` would pass. Keying on the subject rather than on the branch
-      also keeps the rule decidable for commits already on `main`, where the issue
+      also keeps this check decidable for commits already on `main`, where the issue
       branch no longer exists.
 - Branches for an issue are named exactly `GH-<N>`, where `<N>` is the issue number.
-  Commits on such a branch must carry the `GH-<N>: ` subject prefix.
+  Commits on such a branch must carry the `GH-<N>: ` subject prefix, except the merge
+  and revert commits git writes itself — those keep their generated subject.
 - The PR body closes the issue with a `Closes #<N>` keyword. The `GH-<N>: ` subject
   prefix is not a GitHub link and closes nothing.
 - Never add a `Co-Authored-By:` trailer or any other AI attribution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,9 +124,10 @@ Pipeline (`make release X.Y.Z`):
 ## PR/commit checklist
 - `composer ci:test` must pass before every commit.
 - A subject starting with `GH-` must match `^GH-\d+: [A-ZÄÖÜ]`; every other subject
-  must match `^[A-ZÄÖÜ]` — a capitalised imperative either way. **No
-  conventional-commit prefixes** (`feat:`, `fix:`, `chore:` …), no lowercase and no
-  path-like starts (`src/Module.php: …`).
+  must match `^[A-ZÄÖÜ]` — a capitalised imperative either way. The patterns check
+  only the leading capital; two starts are banned whatever their case:
+  **conventional-commit prefixes** (`feat:`, `Fix:`, `chore:` …) and path-like starts
+  (`src/Module.php: …`, `Src/Module.php: …`).
     - The two patterns are deliberately kept separate: `^(GH-\d+: )?[A-ZÄÖÜ]` (wrong)
       stops enforcing the capital *after* the prefix, because the optional group can
       be skipped and the `G` of `GH-` then satisfies `[A-ZÄÖÜ]` on its own —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,8 +123,8 @@ Pipeline (`make release X.Y.Z`):
 
 ## PR/commit checklist
 - `composer ci:test` must pass before every commit.
-- Commit subjects match `^(GH-<N>: )?[A-ZÄÖÜ]` — a capitalised imperative, with the
-  `GH-<N>: ` prefix on issue-tied work. **No conventional-commit prefixes**
+- Commit subjects match `^(GH-\d+: )?[A-ZÄÖÜ]` — a capitalised imperative, with the
+  `GH-<N>: ` prefix (`<N>` being the issue number) on issue-tied work. **No conventional-commit prefixes**
   (`feat:`, `fix:`, `chore:` …), no lowercase or path-like starts. Branches for an
   issue are named exactly `GH-<N>`.
 - Never add a `Co-Authored-By:` trailer or any other AI attribution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,17 +123,21 @@ Pipeline (`make release X.Y.Z`):
 
 ## PR/commit checklist
 - `composer ci:test` must pass before every commit.
-- Commit subjects match `^GH-\d+: [A-ZÄÖÜ]` on issue-tied work and `^[A-ZÄÖÜ]`
-  otherwise — a capitalised imperative either way. **No conventional-commit prefixes**
+- A subject starting with `GH-` must match `^GH-\d+: [A-ZÄÖÜ]`; every other subject
+  must match `^[A-ZÄÖÜ]` — a capitalised imperative either way. On a `GH-<N>` branch
+  the `GH-<N>: ` prefix is mandatory. **No conventional-commit prefixes**
   (`feat:`, `fix:`, `chore:` …), no lowercase and no path-like starts
   (`src/Module.php: …`). Tool-generated subjects (`Merge …`, `Revert "…"`,
   Dependabot) are exempt.
-    - The two patterns are deliberately kept separate. Folded into
-      `^(GH-\d+: )?[A-ZÄÖÜ]` the rule stops enforcing the capital *after* the
-      prefix: the optional group can be skipped, and the `G` of `GH-` then
-      satisfies `[A-ZÄÖÜ]` on its own — `GH-12: fix typo` would pass.
+    - The two patterns are deliberately kept separate: `^(GH-\d+: )?[A-ZÄÖÜ]` (wrong)
+      stops enforcing the capital *after* the prefix, because the optional group can
+      be skipped and the `G` of `GH-` then satisfies `[A-ZÄÖÜ]` on its own —
+      `GH-12: fix typo` would pass. Keying on the subject rather than on the branch
+      also keeps the rule decidable for commits already on `main`, where the issue
+      branch no longer exists.
 - Branches for an issue are named exactly `GH-<N>`, where `<N>` is the issue number.
-  Every commit on such a branch counts as issue-tied.
+- The PR body closes the issue with a `Closes #<N>` keyword. The `GH-<N>: ` subject
+  prefix is not a GitHub link and closes nothing.
 - Never add a `Co-Authored-By:` trailer or any other AI attribution.
 - Keep PRs small and focused (~≤300 net LOC) with atomic commits.
 - Ensure coverage ≥90% on touched PHP paths.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,12 +126,14 @@ Pipeline (`make release X.Y.Z`):
 - Commit subjects match `^GH-\d+: [A-ZÄÖÜ]` on issue-tied work and `^[A-ZÄÖÜ]`
   otherwise — a capitalised imperative either way. **No conventional-commit prefixes**
   (`feat:`, `fix:`, `chore:` …), no lowercase and no path-like starts
-  (`src/Module.php: …`).
+  (`src/Module.php: …`). Tool-generated subjects (`Merge …`, `Revert "…"`,
+  Dependabot) are exempt.
     - The two patterns are deliberately kept separate. Folded into
       `^(GH-\d+: )?[A-ZÄÖÜ]` the rule stops enforcing the capital *after* the
       prefix: the optional group can be skipped, and the `G` of `GH-` then
       satisfies `[A-ZÄÖÜ]` on its own — `GH-12: fix typo` would pass.
 - Branches for an issue are named exactly `GH-<N>`, where `<N>` is the issue number.
+  Every commit on such a branch counts as issue-tied.
 - Never add a `Co-Authored-By:` trailer or any other AI attribution.
 - Keep PRs small and focused (~≤300 net LOC) with atomic commits.
 - Ensure coverage ≥90% on touched PHP paths.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,11 +124,10 @@ Pipeline (`make release X.Y.Z`):
 ## PR/commit checklist
 - `composer ci:test` must pass before every commit.
 - A subject starting with `GH-` must match `^GH-\d+: [A-ZÄÖÜ]`; every other subject
-  must match `^[A-ZÄÖÜ]` — a capitalised imperative either way. On a `GH-<N>` branch
-  the `GH-<N>: ` prefix is mandatory. **No conventional-commit prefixes**
-  (`feat:`, `fix:`, `chore:` …), no lowercase and no path-like starts
-  (`src/Module.php: …`). Tool-generated subjects (`Merge …`, `Revert "…"`,
-  Dependabot) are exempt.
+  must match `^[A-ZÄÖÜ]` — a capitalised imperative either way. **No
+  conventional-commit prefixes** (`feat:`, `fix:`, `chore:` …), no lowercase and no
+  path-like starts (`src/Module.php: …`). Tool-generated subjects (`Merge …`,
+  `Revert "…"`) are exempt.
     - The two patterns are deliberately kept separate: `^(GH-\d+: )?[A-ZÄÖÜ]` (wrong)
       stops enforcing the capital *after* the prefix, because the optional group can
       be skipped and the `G` of `GH-` then satisfies `[A-ZÄÖÜ]` on its own —
@@ -136,6 +135,7 @@ Pipeline (`make release X.Y.Z`):
       also keeps the rule decidable for commits already on `main`, where the issue
       branch no longer exists.
 - Branches for an issue are named exactly `GH-<N>`, where `<N>` is the issue number.
+  Commits on such a branch must carry the `GH-<N>: ` subject prefix.
 - The PR body closes the issue with a `Closes #<N>` keyword. The `GH-<N>: ` subject
   prefix is not a GitHub link and closes nothing.
 - Never add a `Co-Authored-By:` trailer or any other AI attribution.


### PR DESCRIPTION
Follow-up to the review thread on #241.

`AGENTS.md` presented the commit-subject rule as a regex literal:

```
^(GH-<N>: )?[A-ZÄÖÜ]
```

`<N>` is a prose placeholder, not regex syntax. Read as an expression it matches the three literal characters `<`, `N`, `>`, so an agent applying the pattern verbatim would reject a well-formed `GH-241: …` subject — the exact format the document is trying to prescribe.

Corrected to `^(GH-\d+: )?[A-ZÄÖÜ]`, with the placeholder kept in the explanatory text where it belongs.

Documentation only. The same line was copied into the pedigree-chart and descendants-chart modules and is being corrected there as well.