### PR TITLE
GH-251: Wire the repository into the shared commit-convention gate

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,30 @@
+name: Commit lint
+
+# `edited` and the concurrency group are a package, not two independent choices.
+# The gate checks the pull-request title because this repository squash-merges,
+# and the default activity types do not include title edits — without `edited` a
+# title broken after a green run is never re-judged, and a title fixed after a red
+# one has nothing to re-run. But `edited` also makes several runs fire against the
+# same head commit, and branch protection keeps whichever finishes last: a green
+# run started before a title was broken can overwrite the red one that followed.
+# Cancelling in progress removes that race, and is safe because this gate mutates
+# nothing — only the newest title is meant to be judged.
+#
+# The calling job deliberately declares no `permissions:` block of its own: a
+# job-level block would replace the top-level one rather than merge with it, so
+# leaving it off is what makes the top-level grant below the one in effect.
+on:
+    pull_request:
+        types: [opened, reopened, synchronize, edited]
+
+permissions:
+    contents: read
+    pull-requests: read
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    commit-convention:
+        uses: magicsunday/.github/.github/workflows/commit-convention.yml@main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,7 @@ Pipeline (`make release X.Y.Z`):
   Commits on such a branch must carry the `GH-<N>: ` subject prefix, except the merge
   and revert commits git writes itself — those keep their generated subject. Not every
   git-written subject is exempt, though: `fixup!` and `squash!` start lowercase and
-  fail, so autosquash before opening the PR. The gate does not check this half; keyed
+  fail, so autosquash them before opening the PR. The gate does not check this half; keyed
   on the subject alone, it asks only `^[A-ZÄÖÜ]` of an unprefixed subject, whatever
   branch the commit sits on.
 - The PR body closes the issue with a `Closes #<N>` keyword. The `GH-<N>: ` subject

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ Pipeline (`make release X.Y.Z`):
     - The same two patterns judge the **pull-request title**, which under
       squash-merge is the subject that reaches `main`.
     - This is checked, not only documented: `.github/workflows/commit-lint.yml` calls
-      `magicsunday/.github/.github/workflows/commit-convention.yml`, which holds the
+      `magicsunday/.github/.github/workflows/commit-convention.yml@main`, which holds the
       normative definition and judges the title and the subject of every commit — not
       the message body. Where this text and that workflow disagree, the workflow is
       authoritative and this text is what gets fixed. That check is **not yet

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,16 +134,21 @@ Pipeline (`make release X.Y.Z`):
       `GH-12: fix typo` would pass. Keying on the subject rather than on the branch
       also keeps this check decidable for commits already on `main`, where the issue
       branch no longer exists.
-    - This is enforced, not merely documented: `.github/workflows/commit-lint.yml`
-      calls the shared gate, which judges the pull-request title and the subject of
-      every commit — not the message body — against a decision table it self-tests
-      first. Where this text and the gate disagree, the gate is authoritative — fix
-      the text.
+    - The same two patterns judge the **pull-request title**, which under
+      squash-merge is the subject that reaches `main`.
+    - This is checked, not only documented: `.github/workflows/commit-lint.yml` calls
+      `magicsunday/.github/.github/workflows/commit-convention.yml`, which holds the
+      normative definition and judges the title and the subject of every commit — not
+      the message body. Where this text and that workflow disagree, the workflow is
+      authoritative and this text is what gets fixed. It is **not yet a required
+      status check** on `main`, so a red run is advisory until the context
+      `commit-convention / Commit convention` is added to branch protection.
+      `fixup!` / `squash!` subjects fail it; autosquash before opening the PR.
 - Branches for an issue are named exactly `GH-<N>`, where `<N>` is the issue number.
   Commits on such a branch must carry the `GH-<N>: ` subject prefix, except the merge
   and revert commits git writes itself — those keep their generated subject. The gate
-  cannot check this half: it is keyed on the subject alone, so a subject with no
-  prefix passes the gate regardless of the branch the commit sits on.
+  does not check this half; keyed on the subject alone, it asks only `^[A-ZÄÖÜ]` of an
+  unprefixed subject, whatever branch the commit sits on.
 - The PR body closes the issue with a `Closes #<N>` keyword. The `GH-<N>: ` subject
   prefix is not a GitHub link and closes nothing.
 - Never add a `Co-Authored-By:` trailer or any other AI attribution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,15 +140,16 @@ Pipeline (`make release X.Y.Z`):
       `magicsunday/.github/.github/workflows/commit-convention.yml`, which holds the
       normative definition and judges the title and the subject of every commit — not
       the message body. Where this text and that workflow disagree, the workflow is
-      authoritative and this text is what gets fixed. It is **not yet a required
-      status check** on `main`, so a red run is advisory until the context
+      authoritative and this text is what gets fixed. That check is **not yet
+      required** on `main`, so a red run is advisory until the context
       `commit-convention / Commit convention` is added to branch protection.
-      `fixup!` / `squash!` subjects fail it; autosquash before opening the PR.
 - Branches for an issue are named exactly `GH-<N>`, where `<N>` is the issue number.
   Commits on such a branch must carry the `GH-<N>: ` subject prefix, except the merge
-  and revert commits git writes itself — those keep their generated subject. The gate
-  does not check this half; keyed on the subject alone, it asks only `^[A-ZÄÖÜ]` of an
-  unprefixed subject, whatever branch the commit sits on.
+  and revert commits git writes itself — those keep their generated subject. Not every
+  git-written subject is exempt, though: `fixup!` and `squash!` start lowercase and
+  fail, so autosquash before opening the PR. The gate does not check this half; keyed
+  on the subject alone, it asks only `^[A-ZÄÖÜ]` of an unprefixed subject, whatever
+  branch the commit sits on.
 - The PR body closes the issue with a `Closes #<N>` keyword. The `GH-<N>: ` subject
   prefix is not a GitHub link and closes nothing.
 - Never add a `Co-Authored-By:` trailer or any other AI attribution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,14 +135,15 @@ Pipeline (`make release X.Y.Z`):
       also keeps this check decidable for commits already on `main`, where the issue
       branch no longer exists.
     - This is enforced, not merely documented: `.github/workflows/commit-lint.yml`
-      calls the shared gate, which judges the pull-request title and every commit
-      against a decision table it self-tests first. Where this text and the gate
-      disagree, the gate is authoritative — fix the text.
+      calls the shared gate, which judges the pull-request title and the subject of
+      every commit — not the message body — against a decision table it self-tests
+      first. Where this text and the gate disagree, the gate is authoritative — fix
+      the text.
 - Branches for an issue are named exactly `GH-<N>`, where `<N>` is the issue number.
   Commits on such a branch must carry the `GH-<N>: ` subject prefix, except the merge
   and revert commits git writes itself — those keep their generated subject. The gate
   cannot check this half: it is keyed on the subject alone, so a subject with no
-  prefix passes it whatever branch the commit sits on.
+  prefix passes the gate regardless of the branch the commit sits on.
 - The PR body closes the issue with a `Closes #<N>` keyword. The `GH-<N>: ` subject
   prefix is not a GitHub link and closes nothing.
 - Never add a `Co-Authored-By:` trailer or any other AI attribution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,9 +134,15 @@ Pipeline (`make release X.Y.Z`):
       `GH-12: fix typo` would pass. Keying on the subject rather than on the branch
       also keeps this check decidable for commits already on `main`, where the issue
       branch no longer exists.
+    - This is enforced, not merely documented: `.github/workflows/commit-lint.yml`
+      calls the shared gate, which judges the pull-request title and every commit
+      against a decision table it self-tests first. Where this text and the gate
+      disagree, the gate is authoritative — fix the text.
 - Branches for an issue are named exactly `GH-<N>`, where `<N>` is the issue number.
   Commits on such a branch must carry the `GH-<N>: ` subject prefix, except the merge
-  and revert commits git writes itself — those keep their generated subject.
+  and revert commits git writes itself — those keep their generated subject. The gate
+  cannot check this half: it is keyed on the subject alone, so a subject with no
+  prefix passes it whatever branch the commit sits on.
 - The PR body closes the issue with a `Closes #<N>` keyword. The `GH-<N>: ` subject
   prefix is not a GitHub link and closes nothing.
 - Never add a `Co-Authored-By:` trailer or any other AI attribution.


### PR DESCRIPTION
Closes #251.

Adopts the reusable gate from `magicsunday/.github` as the pilot consumer. This repository is the first to wire it in; the remaining modules follow once it has run here for a while.

## What changes

`.github/workflows/commit-lint.yml` calls the shared workflow. `AGENTS.md` gains two statements: that the rule is now enforced and that the gate wins on a disagreement, and that the branch-prefix half is beyond what the gate can check — it is keyed on the subject alone, so a subject with no prefix passes it whatever branch the commit sits on.

The prose rule itself stays. Agents read `AGENTS.md` before they commit, which is earlier than CI can help.

## Caller shape

Three details are load-bearing and are commented in the file, because consumers will copy it:

- `edited` is in the activity types. The gate checks the pull-request title because this repository squash-merges, and the default types do not include title edits — without it a title broken after a green run is never re-judged, and a title fixed after a red one has nothing to re-run.
- The concurrency group cancels in progress. `edited` makes several runs fire against the same head commit, and branch protection keeps whichever *finishes* last, so a green run started before a title was broken could overwrite the red one that followed.
- The calling job declares no `permissions:` of its own. A job-level block replaces the top-level one rather than merging with it, so omitting it is what puts the top-level `pull-requests: read` in effect. A caller that narrows it at job level is rejected before any step runs.

## Verification

The gate self-tests its predicate against a 25-row decision table before applying it, and fails if it reads fewer rows than expected. On its own pull request in the `.github` repository it reported `predicate agrees with all 25 cases` and `title and all 7 commit subjects follow the convention` — so it is demonstrably not passing vacuously, which earlier revisions could.

This pull request is its first run against a real consumer. Both the title and the single commit subject carry the `GH-251: ` prefix, so the run exercises the prefixed branch of the rule rather than only the plain one.