### PR TITLE
Run the bundle freshness check once per pull request, not twice

### DIFF
--- a/.github/workflows/bundle-freshness.yml
+++ b/.github/workflows/bundle-freshness.yml
@@ -2,6 +2,7 @@ name: Bundle
 
 on:
     push:
+        branches: [main, master, '*.x', WIP]
     pull_request:
 
 permissions:


### PR DESCRIPTION
The last workflow in this repository that still ran twice per pull request.

`bundle-freshness.yml` triggered on both an unfiltered `push:` and `pull_request:`, so both fired for a branch with an open PR and the check ran twice for the same commit. `ci.yml` carried the identical defect and was fixed; this closes the gap.

The `push` trigger is scoped the same way, including the long-lived `*.x` and `WIP` branches that are maintained by direct push and would otherwise lose the check entirely. A pull request still runs it through the unchanged `pull_request` trigger.

`bundle-freshness` is **not** a required status check here (the required set is `build (8.3|8.4|8.5)` plus `catalogue / Catalogue layout`, the latter from `i18n.yml`, which is already scoped), so no branch protection is affected either way.