### PR TITLE
GH-255: Memoise per-node Configuration getters

### DIFF
--- a/resources/lang/af/messages.po
+++ b/resources/lang/af/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "'n Waaierdiagram van 'n persoon se voorouers."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Verkort eers voorname"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Verkort eers vanne"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Outomaties (gebaseer op die boom se vannaam-tradisie)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgstr "Waaiergrootte"
 msgid "Font size"
 msgstr "Skrifgrootte"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Volledige pleknaam"
 
@@ -192,15 +192,15 @@ msgstr ""
 "die van in (bv. Martin \"Chalky\" White). Boots die ouer webtrees-gedrag na "
 "vir bome wat bynaame in die afsonderlike GEDCOM NICK-veld stoor."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Laagste vlak (bv. gemeente)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Laagste drie vlakke"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "Laagste twee vlakke"
 
@@ -240,15 +240,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Vaderlik"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgstr ""
 "verberg. Afstammelinge met smal boogies gebruik outomaties 'n kompakte slegs-"
 "jaar-formaat."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Wys volledige datums tot generasie %s"
@@ -351,7 +351,7 @@ msgstr ""
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Gebruik Ctrl + rol om te vergroot"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Slegs jare"
 

--- a/resources/lang/cs/messages.po
+++ b/resources/lang/cs/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Vějíř předků osoby."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Nejprve zkrátit křestní jména"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Nejprve zkrátit příjmení"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automaticky (podle tradice příjmení stromu)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgstr "Velikost vějíře"
 msgid "Font size"
 msgstr "Velikost písma"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Úplný název místa"
 
@@ -191,15 +191,15 @@ msgstr ""
 "Martin \"Chalky\" White). Napodobuje původní chování webtrees pro stromy, "
 "které přezdívky ukládají do samostatného pole GEDCOM NICK."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Nejnižší úroveň (např. farnost)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Nejnižší tři úrovně"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "Nejnižší dvě úrovně"
 
@@ -239,15 +239,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Otcovský"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 "generace 9. Potomci s úzkými oblouky automaticky používají kompaktní formát "
 "pouze s rokem."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Zobrazit úplná data do generace %s"
@@ -350,7 +350,7 @@ msgstr ""
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Pomocí Ctrl + kolečko zvětšit pohled"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Pouze roky"
 

--- a/resources/lang/de/messages.po
+++ b/resources/lang/de/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Ein Fächerdiagramm der Vorfahren einer Person."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Zuerst Vornamen abkürzen"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Zuerst Nachnamen abkürzen"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (basierend auf der Nachnamen-Tradition des Stammbaums)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr "Automatisch (aus der Baumkonfiguration)"
 
@@ -135,7 +135,7 @@ msgstr "Fächergröße"
 msgid "Font size"
 msgstr "Schriftgröße"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Vollständiger Ortsname"
 
@@ -197,15 +197,15 @@ msgstr ""
 "Verhalten für Bäume nach, die Spitznamen im separaten GEDCOM NICK-Feld "
 "speichern."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Unterste Ebene (z.B. Kirchgemeinde)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Unterste drei Ebenen"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "Unterste zwei Ebenen"
 
@@ -245,15 +245,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Väterlich"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr "Ort und Land"
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr "Ort und Ländercode (2 Buchstaben)"
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr "Ort und Ländercode (3 Buchstaben)"
 
@@ -296,7 +296,7 @@ msgstr ""
 "ab Generation 9 ausgeblendet. Nachkommen mit schmalen Bögen verwenden "
 "automatisch ein kompaktes Nur-Jahr-Format."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Zeige vollständige Daten bis Generation %s"
@@ -356,7 +356,7 @@ msgstr ""
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Verwende Strg+Scrollen zum Zoomen der Ansicht"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Nur Jahreszahlen"
 

--- a/resources/lang/en-GB/messages.po
+++ b/resources/lang/en-GB/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "A fan chart of an individual’s ancestors."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Abbreviate given names first"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Abbreviate surnames first"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatic (based on tree's surname tradition)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr "Automatic (from the tree configuration)"
 
@@ -135,7 +135,7 @@ msgstr "Fan size"
 msgid "Font size"
 msgstr "Font size"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Full place name"
 
@@ -195,15 +195,15 @@ msgstr ""
 "surname (e.g. Martin \"Chalky\" White). Mirrors the legacy webtrees "
 "behaviour for trees that store nicknames in the separate GEDCOM NICK field."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Lowest level (e.g. parish)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Lowest three levels"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "Lowest two levels"
 
@@ -243,15 +243,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Paternal"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr "Place and country"
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr "Place and country code (2 letters)"
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr "Place and country code (3 letters)"
 
@@ -293,7 +293,7 @@ msgstr ""
 "generations show year only. Marriage dates are hidden from generation 9. "
 "Descendants with narrow arcs automatically use a compact year-only format."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Show full dates up to generation %s"
@@ -353,7 +353,7 @@ msgstr "The preferences for the module “%s” have been updated."
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Use Ctrl+Scroll wheel to zoom the chart"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Years only"
 

--- a/resources/lang/en-US/messages.po
+++ b/resources/lang/en-US/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "A fan chart of an individual’s ancestors."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Abbreviate given names first"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Abbreviate surnames first"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatic (based on tree's surname tradition)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr "Automatic (from the tree configuration)"
 
@@ -135,7 +135,7 @@ msgstr "Fan size"
 msgid "Font size"
 msgstr "Font size"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Full place name"
 
@@ -195,15 +195,15 @@ msgstr ""
 "surname (e.g. Martin \"Chalky\" White). Mirrors the legacy webtrees "
 "behaviour for trees that store nicknames in the separate GEDCOM NICK field."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Lowest level (e.g. parish)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Lowest three levels"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "Lowest two levels"
 
@@ -243,15 +243,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Paternal"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr "Place and country"
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr "Place and country code (2 letters)"
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr "Place and country code (3 letters)"
 
@@ -293,7 +293,7 @@ msgstr ""
 "generations show year only. Marriage dates are hidden from generation 9. "
 "Descendants with narrow arcs automatically use a compact year-only format."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Show full dates up to generation %s"
@@ -353,7 +353,7 @@ msgstr "The preferences for the module “%s” have been updated."
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Use Ctrl + scroll to zoom in the view"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Years only"
 

--- a/resources/lang/es/messages.po
+++ b/resources/lang/es/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Un diagrama de abanico de los antepasados de un individuo."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Abreviar primero los nombres de pila"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Abreviar primero los apellidos"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automático (según la tradición de apellidos del árbol)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr "Ángulo del abanico"
 msgid "Font size"
 msgstr "Tamaño tipografía"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Nombre completo del lugar"
 
@@ -194,15 +194,15 @@ msgstr ""
 "webtrees para árboles que guardan los apodos en el campo GEDCOM NICK "
 "separado."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Nivel más bajo (p. ej. parroquia)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Tres niveles más bajos"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "Dos niveles más bajos"
 
@@ -243,15 +243,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Paterno"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -295,7 +295,7 @@ msgstr ""
 "descendientes con arcos estrechos usan automáticamente un formato compacto "
 "de solo año."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Mostrar fechas completas hasta la generación %s"
@@ -355,7 +355,7 @@ msgstr ""
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Use Ctrl + scroll para acercar la vista"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Solo años"
 

--- a/resources/lang/fi/messages.po
+++ b/resources/lang/fi/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Viuhkakaavio henkilön esi-isistä."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Lyhennä ensin etunimet"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Lyhennä ensin sukunimet"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automaattinen (sukupuun sukunimitradition mukaan)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgstr "Viuhkan koko"
 msgid "Font size"
 msgstr "Fonttikoko"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Koko paikannimi"
 
@@ -193,15 +193,15 @@ msgstr ""
 "sukupuille, joissa lempinimet on tallennettu erilliseen GEDCOM NICK "
 "-kenttään."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Alin taso (esim. seurakunta)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Kolme alinta tasoa"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "Kaksi alinta tasoa"
 
@@ -241,15 +241,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Isänpuoleinen"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgstr ""
 "Avioliittopäivämäärät piilotetaan sukupolvesta 9 alkaen. Kapeiden kaarien "
 "jälkeläiset käyttävät automaattisesti kompaktia vain vuosi -muotoa."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Näytä tarkat päivämäärät sukupolveen %s asti"
@@ -352,7 +352,7 @@ msgstr ""
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Zoomaa näkymää käyttämällä ohjausnäppäintä (Ctrl) + rullauslaitetta"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Vain vuodet"
 

--- a/resources/lang/fr/messages.po
+++ b/resources/lang/fr/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Un éventail des ancêtres d'un individu."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Abréger d'abord les prénoms"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Abréger d'abord les noms de famille"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatique (selon la tradition des noms de famille de l'arbre)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr "Automatique (d'après la configuration de l'arbre)"
 
@@ -137,7 +137,7 @@ msgstr "Taille de l'éventail"
 msgid "Font size"
 msgstr "Taille de police"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Nom complet du lieu"
 
@@ -195,15 +195,15 @@ msgstr ""
 "de webtrees pour les arbres qui stockent les surnoms dans le champ GEDCOM "
 "NICK séparé."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Niveau le plus bas (ex. paroisse)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Trois niveaux les plus bas"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "Deux niveaux les plus bas"
 
@@ -244,15 +244,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Paternel"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -296,7 +296,7 @@ msgstr ""
 "arcs étroits utilisent automatiquement un format compact avec l'année "
 "uniquement."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Afficher les dates complètes jusqu'à la génération %s"
@@ -356,7 +356,7 @@ msgstr ""
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Utiliser Ctrl + molette pour zoomer dans la vue"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Années uniquement"
 

--- a/resources/lang/he/messages.po
+++ b/resources/lang/he/messages.po
@@ -23,19 +23,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "תרשים מעריצים של אבותיו של אדם."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "קצר תחילה את השמות הפרטיים"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "קצר תחילה את שמות המשפחה"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "אוטומטי (על פי מסורת שם המשפחה של העץ)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgstr "גודל מאוורר"
 msgid "Font size"
 msgstr "גודל גופן"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "שם מקום מלא"
 
@@ -190,15 +190,15 @@ msgstr ""
 "Martin \"Chalky\" White). משחזר את התנהגות webtrees הישנה עבור עצים השומרים "
 "כינויים בשדה GEDCOM NICK הנפרד."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "רמה נמוכה ביותר (למשל קהילה)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "שלוש הרמות הנמוכות ביותר"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "שתי הרמות הנמוכות ביותר"
 
@@ -238,15 +238,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "אבהי"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -288,7 +288,7 @@ msgstr ""
 "מציגים שנה בלבד. תאריכי נישואין מוסתרים מדור 9. צאצאים עם קשתות צרות משתמשים "
 "אוטומטית בפורמט שנה בלבד."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "הצג תאריכים מלאים עד דור %s"
@@ -347,7 +347,7 @@ msgstr ""
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "השתמש ב- Ctrl + גלילה כדי להגדיל את התצוגה"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "שנים בלבד"
 

--- a/resources/lang/hi/messages.po
+++ b/resources/lang/hi/messages.po
@@ -21,19 +21,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "किसी व्यक्ती के पूर्वजों का एक फैन चार्ट।"
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "पहले प्रदत्त नामों को संक्षिप्त करें"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "पहले उपनामों को संक्षिप्त करें"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "स्वचालित (वृक्ष की उपनाम परंपरा पर आधारित)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -132,7 +132,7 @@ msgstr "फैन का आकार"
 msgid "Font size"
 msgstr "फ़ॉन्ट आकार"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "पूरा स्थान नाम"
 
@@ -189,15 +189,15 @@ msgstr ""
 "(जैसे Martin \"Chalky\" White)। उन वृक्षों के लिए पुराने webtrees व्यवहार का अनुकरण "
 "करता है जो उपनामों को अलग GEDCOM NICK फ़ील्ड में संग्रहीत करते हैं।"
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "सबसे निचला स्तर (जैसे पल्ली)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "सबसे निचले तीन स्तर"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "सबसे निचले दो स्तर"
 
@@ -237,15 +237,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "पैतृक"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -287,7 +287,7 @@ msgstr ""
 "वर्ष दिखाती हैं। विवाह तिथियाँ पीढ़ी 9 से छिपी होती हैं। संकीर्ण चापों वाले वंशज स्वचालित "
 "रूप से एक संक्षिप्त केवल-वर्ष प्रारूप का उपयोग करते हैं।"
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "पीढ़ी %s तक पूर्ण तिथियाँ दिखाएँ"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Ctrl + Scroll से ज़ूम इन करें"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "केवल वर्ष"
 

--- a/resources/lang/is/messages.po
+++ b/resources/lang/is/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Skífurit yfir forfeður einstaklings."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Stytta eiginnöfn fyrst"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Stytta eftirnöfn fyrst"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Sjálfvirkt (byggt á eftirnafnshefð trésins)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgstr "Skífustærð"
 msgid "Font size"
 msgstr "Leturstærð"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Fullt heiti staðar"
 
@@ -192,15 +192,15 @@ msgstr ""
 "(t.d. Martin \"Chalky\" White). Líkir eftir gamla webtrees-hegðuninni fyrir "
 "tré sem geyma gælunöfn í sérstaka GEDCOM NICK-reitinn."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Lægsta stig (t.d. sókn)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Þrjú lægstu stig"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "Tvö lægstu stig"
 
@@ -240,15 +240,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Föðurleg"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgstr ""
 "kynslóð 9. Afkomendur með mjóa boga nota sjálfkrafa þjappað snið með aðeins "
 "ári."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Sýna fulla dagsetningar til kynslóðar %s"
@@ -351,7 +351,7 @@ msgstr "Kjörstillingar fyrir eininguna “%s” hafa verið uppfærðar."
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Notaðu Ctrl + skruna til að þysja í ættartrénu"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Aðeins ár"
 

--- a/resources/lang/it/messages.po
+++ b/resources/lang/it/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Un grafico a ventaglio degli antenati di una persona."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Abbrevia prima i nomi propri"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Abbrevia prima i cognomi"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatico (in base alla tradizione dei cognomi dell'albero)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr "Impostare i gradi di apertura del grafico"
 msgid "Font size"
 msgstr "Dimensione dei caratteri"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Nome completo del luogo"
 
@@ -193,15 +193,15 @@ msgstr ""
 "Martin \"Chalky\" White). Riproduce il comportamento storico di webtrees per "
 "alberi che memorizzano i soprannomi nel campo GEDCOM NICK separato."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Livello più basso (es. parrocchia)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Tre livelli più bassi"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "Due livelli più bassi"
 
@@ -242,15 +242,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Paterno"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -293,7 +293,7 @@ msgstr ""
 "matrimonio sono nascoste dalla generazione 9. I discendenti con archi "
 "stretti utilizzano automaticamente un formato compatto con solo l'anno."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Mostra date complete fino alla generazione %s"
@@ -353,7 +353,7 @@ msgstr "Le preferenze per il modulo \"%s\" sono state aggiornate."
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Usare Ctrl + scorrimento per ingrandire la vista"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Solo anni"
 

--- a/resources/lang/nb/messages.po
+++ b/resources/lang/nb/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Et viftediagram over en persons aner."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Forkort fornavn først"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternavn først"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på treets etternavnstradisjon)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgstr "Viftestørrelse"
 msgid "Font size"
 msgstr "Fontstørrelse"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Fullt stedsnavn"
 
@@ -191,15 +191,15 @@ msgstr ""
 "(f.eks. Martin \"Chalky\" White). Gjenskaper den tidligere webtrees-"
 "oppførselen for trær som lagrer kallenavn i det separate GEDCOM NICK-feltet."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Laveste nivå (f.eks. sokn)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Tre laveste nivåer"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "To laveste nivåer"
 
@@ -239,15 +239,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Farslinje"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 "generasjon 9. Etterkommere med smale buer bruker automatisk et kompakt kun-"
 "årstall-format."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Vis fullstendige datoer til generasjon %s"
@@ -350,7 +350,7 @@ msgstr ""
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Bruk Ctrl + scroll for zoom"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Kun årstall"
 

--- a/resources/lang/nl/messages.po
+++ b/resources/lang/nl/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Een waaierdiagram met de voorouders van een persoon."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Voornamen eerst afkorten"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Achternamen eerst afkorten"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisch (op basis van de achternaamtraditie van de stamboom)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr "Automatisch (op basis van de stamboomconfiguratie)"
 
@@ -135,7 +135,7 @@ msgstr "Waaierhoek"
 msgid "Font size"
 msgstr "Tekstgrootte"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Volledige plaatsnaam"
 
@@ -193,15 +193,15 @@ msgstr ""
 "gedrag na voor stambomen die bijnamen in het afzonderlijke GEDCOM NICK-veld "
 "opslaan."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Laagste niveau (bijv. parochie)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Laagste drie niveaus"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "Laagste twee niveaus"
 
@@ -241,15 +241,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Vaderlijk"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgstr ""
 "verborgen vanaf generatie 9. Afstammelingen met smalle bogen gebruiken "
 "automatisch een compact alleen-jaar-formaat."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Toon volledige data tot generatie %s"
@@ -352,7 +352,7 @@ msgstr "De voorkeuren voor de module \"%s\" zijn bijgewerkt."
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Gebruik Ctrl + scroll om in te zoomen op de weergave"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Alleen jaren"
 

--- a/resources/lang/nn/messages.po
+++ b/resources/lang/nn/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Eit viftediagram over ein person sine anar."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Forkort førenamn først"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Forkort etternamn først"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatisk (basert på etternamnstradisjonen til treet)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgstr "Viftestorleik"
 msgid "Font size"
 msgstr "Fontstorleik"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Fullt stadnamn"
 
@@ -191,15 +191,15 @@ msgstr ""
 "Martin \"Chalky\" White). Tek att den gamle webtrees-åtferda for tre som "
 "lagrar kallenamn i det separate GEDCOM NICK-feltet."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Lågaste nivå (t.d. sokn)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Tre lågaste nivå"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "To lågaste nivå"
 
@@ -239,15 +239,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Farslinje"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 "generasjon 9. Etterkomarar med smale bogar brukar automatisk eit kompakt "
 "berre-årstal-format."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Vis fullstendige datoar til generasjon %s"
@@ -349,7 +349,7 @@ msgstr ""
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Bruk Ctrl + scroll for zoom"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Berre årstal"
 

--- a/resources/lang/pt/messages.po
+++ b/resources/lang/pt/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Diagrama em leque dos ascendentes de um indivíduo."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Abreviar primeiro os nomes próprios"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Abreviar primeiro os sobrenomes"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automático (com base na tradição de sobrenomes da árvore)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgstr "Amplitude do leque"
 msgid "Font size"
 msgstr "Tamanho da fonte"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Nome completo do local"
 
@@ -192,15 +192,15 @@ msgstr ""
 "(ex. Martin \"Chalky\" White). Reproduz o comportamento antigo do webtrees "
 "para árvores que armazenam apelidos no campo GEDCOM NICK separado."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Nível mais específico (ex: freguesia ou lugar)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Três níveis mais específicos"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "Dois níveis mais específicos"
 
@@ -240,15 +240,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Paterno"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgstr ""
 "são ocultadas a partir da geração 9. Os descendentes com arcos estreitos "
 "utilizam automaticamente um formato compacto apenas com o ano."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Mostrar as datas completas até à geração %s"
@@ -351,7 +351,7 @@ msgstr "As preferências do módulo \"%s\" foram atualizadas."
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Usar Ctrl + roda do rato para aproximar ou afastar"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Apenas anos"
 

--- a/resources/lang/ru/messages.po
+++ b/resources/lang/ru/messages.po
@@ -23,19 +23,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Веерный график персоны."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Сокращать сначала имена"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Сокращать сначала фамилии"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматически (по традиции фамилий дерева)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgstr "Размер веера"
 msgid "Font size"
 msgstr "Размер шрифта"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Полное название места"
 
@@ -192,15 +192,15 @@ msgstr ""
 "(например, Martin \"Chalky\" White). Повторяет прежнее поведение webtrees "
 "для деревьев, в которых прозвища хранятся в отдельном поле GEDCOM NICK."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Нижний уровень (напр. приход)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Три нижних уровня"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "Два нижних уровня"
 
@@ -240,15 +240,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Отцовская линия"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgstr ""
 "скрываются с поколения 9. Потомки с узкими дугами автоматически используют "
 "компактный формат только с годом."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Показать полные даты до поколения %s"
@@ -351,7 +351,7 @@ msgstr ""
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Используйте Ctrl + колёсико мыши, чтобы увеличить"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Только годы"
 

--- a/resources/lang/sl/messages.po
+++ b/resources/lang/sl/messages.po
@@ -25,19 +25,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Pahljačasti diagram posameznikovih prednikov."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Najprej skrajšaj osebna imena"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Najprej skrajšaj priimke"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Samodejno (glede na drevesno tradicijo priimkov)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -137,7 +137,7 @@ msgstr "Velikost pahljače"
 msgid "Font size"
 msgstr "Velikost pisave"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Polno ime kraja"
 
@@ -194,15 +194,15 @@ msgstr ""
 "Martin \"Chalky\" White). Posnema staro vedenje webtrees za drevesa, ki "
 "vzdevke shranjujejo v ločenem polju GEDCOM NICK."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Najnižja raven (npr. župnija)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Najnižje tri ravni"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "Najnižji dve ravni"
 
@@ -242,15 +242,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Očetov"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgstr ""
 "generacije prikazujejo samo leto. Datumi poroke so skriti od generacije 9. "
 "Potomci z ozkimi loki samodejno uporabljajo kompakten format samo z letom."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Prikaži polne datume do generacije %s"
@@ -352,7 +352,7 @@ msgstr "Nastavitve modula “%s” so posodobljene."
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Uporabi Ctrl+Scroll kolesce za povečavo diagrama"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Samo leta"
 

--- a/resources/lang/sr-Latn/messages.po
+++ b/resources/lang/sr-Latn/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Lepeza grafikon predaka pojedinca."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Prvo skrati lična imena"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Prvo skrati prezimena"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatski (na osnovu tradicije prezimena stabla)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgstr "Veličina lepeze"
 msgid "Font size"
 msgstr "Veličina fonta"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Puno ime mesta"
 
@@ -191,15 +191,15 @@ msgstr ""
 "(npr. Martin \"Chalky\" White). Oponaša staro webtrees ponašanje za stabla "
 "koja nadimke čuvaju u zasebnom polju GEDCOM NICK."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Najniži nivo (npr. parohija)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Najniža tri nivoa"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "Najniža dva nivoa"
 
@@ -239,15 +239,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Očev"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 "Potomci sa uskim lukovima automatski koriste kompaktan format samo sa "
 "godinom."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Prikaži pune datume do generacije %s"
@@ -350,7 +350,7 @@ msgstr ""
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Koristi CTRL+ skrol za zumiranje u prikazu"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Samo godine"
 

--- a/resources/lang/sr/messages.po
+++ b/resources/lang/sr/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Лепеза графикон појединчевих предака."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Прво скрати лична имена"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Прво скрати презимена"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Аутоматски (на основу традиције презимена стабла)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgstr "Величина лепезе"
 msgid "Font size"
 msgstr "Величина слова"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Пуно име места"
 
@@ -191,15 +191,15 @@ msgstr ""
 "(нпр. Martin \"Chalky\" White). Опонаша старо webtrees понашање за стабла "
 "која надимке чувају у засебном пољу GEDCOM NICK."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Најнижи ниво (нпр. парохија)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Најнижа три нивоа"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "Најнижа два нивоа"
 
@@ -239,15 +239,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Очев"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 "Потомци са уским луковима аутоматски користе компактан формат само са "
 "годином."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Прикажи пуне датуме до генерације %s"
@@ -350,7 +350,7 @@ msgstr ""
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Користите CTRL + скрол да бисте зумирали приказ"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Само године"
 

--- a/resources/lang/sv/messages.po
+++ b/resources/lang/sv/messages.po
@@ -24,19 +24,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Ett solfjäderdiagram med en persons förfäder."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Förkorta förnamn först"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Förkorta efternamn först"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Automatiskt (baserat på trädets efternamnstradition)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr "Diagramstorlek"
 msgid "Font size"
 msgstr "Fontstorlek"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Fullständigt platsnamn"
 
@@ -193,15 +193,15 @@ msgstr ""
 "(t.ex. Martin \"Chalky\" White). Återskapar det tidigare webtrees-beteendet "
 "för träd som lagrar smeknamn i det separata GEDCOM NICK-fältet."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Lägsta nivå (t.ex. församling)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Tre lägsta nivåer"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "Två lägsta nivåer"
 
@@ -241,15 +241,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Faderlig"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgstr ""
 "9. Ättlingar med smala bågar använder automatiskt ett kompakt format med "
 "bara årtal."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Visa fullständiga datum till generation %s"
@@ -352,7 +352,7 @@ msgstr ""
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Använd Ctrl + rullen för att zooma in vyn"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Endast år"
 

--- a/resources/lang/uk/messages.po
+++ b/resources/lang/uk/messages.po
@@ -23,19 +23,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Віялова діаграма предків особи."
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Спершу скорочувати імена"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Спершу скорочувати прізвища"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Автоматично (за традицією прізвищ дерева)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgstr "Розмір віяла"
 msgid "Font size"
 msgstr "Розмір шрифту"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Повна назва місця"
 
@@ -192,15 +192,15 @@ msgstr ""
 "Martin \"Chalky\" White). Повторює попередню поведінку webtrees для дерев, "
 "які зберігають прізвиська в окремому полі GEDCOM NICK."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Найнижчий рівень (напр. парафія)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Три найнижчих рівні"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "Два найнижчих рівні"
 
@@ -240,15 +240,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "По батьківській лінії"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgstr ""
 "Нащадки з вузькими дугами автоматично використовують компактний формат лише "
 "з роком."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Показати повні дати до покоління %s"
@@ -351,7 +351,7 @@ msgstr ""
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Використовуйте Ctrl + коліщатко миші для збільшення зображення"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Лише роки"
 

--- a/resources/lang/vi/messages.po
+++ b/resources/lang/vi/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Biểu đồ cá nhân Tổ tiên"
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "Viết tắt tên gọi trước"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "Viết tắt họ trước"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "Tự động (dựa trên truyền thống họ của cây phả hệ)"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgstr "Kích thước biểu đồ"
 msgid "Font size"
 msgstr "Kích thước font chữ"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "Tên địa điểm đầy đủ"
 
@@ -191,15 +191,15 @@ msgstr ""
 "Martin \"Chalky\" White). Tái hiện hành vi webtrees cũ cho cây gia phả lưu "
 "biệt danh trong trường GEDCOM NICK riêng."
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "Cấp thấp nhất (ví dụ: giáo xứ)"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "Ba cấp thấp nhất"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "Hai cấp thấp nhất"
 
@@ -239,15 +239,15 @@ msgstr ""
 msgid "Paternal"
 msgstr "Bên nội"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -289,7 +289,7 @@ msgstr ""
 "chỉ hiển thị năm. Ngày kết hôn bị ẩn từ thế hệ 9. Con cháu có cung hẹp tự "
 "động sử dụng định dạng chỉ năm gọn."
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "Hiển thị đầy đủ ngày tháng đến thế hệ %s"
@@ -349,7 +349,7 @@ msgstr ""
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Kết hợp Ctrl + scroll để thu phóng biểu đồ"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "Chỉ năm"
 

--- a/resources/lang/zh-Hans/messages.po
+++ b/resources/lang/zh-Hans/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "一种以扇形样式显示个人祖先的图表。"
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "优先缩写名字"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "优先缩写姓氏"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "自动（根据族谱的姓氏传统）"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -130,7 +130,7 @@ msgstr "扇形大小"
 msgid "Font size"
 msgstr "字体大小"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "完整地名"
 
@@ -185,15 +185,15 @@ msgstr ""
 "White）。模拟旧版 webtrees 的行为，适用于在单独的 GEDCOM NICK 字段中保存昵称"
 "的家谱。"
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "最低层级（如教区）"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "最低三个层级"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "最低两个层级"
 
@@ -231,15 +231,15 @@ msgstr "配偶和子女显示为祖先部分下方的弧形。启用时扇形大
 msgid "Paternal"
 msgstr "父系"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -280,7 +280,7 @@ msgstr ""
 "为早期世代显示完整日期（出生、婚姻、死亡）。后期世代仅显示年份。婚姻日期从第9"
 "代起隐藏。窄弧的后代自动使用紧凑的仅年份格式。"
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "显示完整日期至第 %s 代"
@@ -339,7 +339,7 @@ msgstr ""
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "按住Ctrl键滚动鼠标滚轮放大缩小"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "仅显示年份"
 

--- a/resources/lang/zh-Hant/messages.po
+++ b/resources/lang/zh-Hant/messages.po
@@ -22,19 +22,19 @@ msgstr ""
 msgid "A fan chart of an individual’s ancestors."
 msgstr "一種以扇形樣式顯示個人祖先的圖表。"
 
-#: src/Configuration.php:640
+#: src/Configuration.php:805
 msgid "Abbreviate given names first"
 msgstr "優先縮寫名字"
 
-#: src/Configuration.php:641
+#: src/Configuration.php:806
 msgid "Abbreviate surnames first"
 msgstr "優先縮寫姓氏"
 
-#: src/Configuration.php:639
+#: src/Configuration.php:804
 msgid "Automatic (based on tree's surname tradition)"
 msgstr "自動（根據族譜的姓氏傳統）"
 
-#: src/Configuration.php:425
+#: src/Configuration.php:562
 msgid "Automatic (from the tree configuration)"
 msgstr ""
 
@@ -130,7 +130,7 @@ msgstr "扇形大小"
 msgid "Font size"
 msgstr "字體大小"
 
-#: src/Configuration.php:426
+#: src/Configuration.php:563
 msgid "Full place name"
 msgstr "完整地名"
 
@@ -185,15 +185,15 @@ msgstr ""
 "White）。模擬舊版 webtrees 的行為，適用於在獨立的 GEDCOM NICK 欄位中儲存暱稱"
 "的家譜。"
 
-#: src/Configuration.php:427
+#: src/Configuration.php:564
 msgid "Lowest level (e.g. parish)"
 msgstr "最低層級（如教區）"
 
-#: src/Configuration.php:429
+#: src/Configuration.php:566
 msgid "Lowest three levels"
 msgstr "最低三個層級"
 
-#: src/Configuration.php:428
+#: src/Configuration.php:565
 msgid "Lowest two levels"
 msgstr "最低兩個層級"
 
@@ -231,15 +231,15 @@ msgstr "配偶和子女顯示為祖先部分下方的弧形。啟用時扇形大
 msgid "Paternal"
 msgstr "父系"
 
-#: src/Configuration.php:430
+#: src/Configuration.php:567
 msgid "Place and country"
 msgstr ""
 
-#: src/Configuration.php:431
+#: src/Configuration.php:568
 msgid "Place and country code (2 letters)"
 msgstr ""
 
-#: src/Configuration.php:432
+#: src/Configuration.php:569
 msgid "Place and country code (3 letters)"
 msgstr ""
 
@@ -280,7 +280,7 @@ msgstr ""
 "為早期世代顯示完整日期（出生、婚姻、死亡）。後期世代僅顯示年份。婚姻日期從第9"
 "代起隱藏。窄弧的後代自動使用緊湊的僅年份格式。"
 
-#: src/Configuration.php:218
+#: src/Configuration.php:318
 #, php-format
 msgid "Show full dates up to generation %s"
 msgstr "顯示完整日期至第 %s 代"
@@ -339,7 +339,7 @@ msgstr ""
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "按住Ctrl鍵滾動鼠標滾輪放大縮小"
 
-#: src/Configuration.php:213
+#: src/Configuration.php:313
 msgid "Years only"
 msgstr "僅顯示年份"
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -136,6 +136,98 @@ class Configuration
      */
     private const int MIN_DETAILED_DATE_GENERATIONS = 0;
 
+    // The getters below are each called once per individual while the tree is
+    // built — up to ~1023 nodes for ten generations, via getRouteToggleParams()
+    // on the click-to-recenter URL and directly from the DataFacade. Both
+    // AbstractModule::getPreference() (an uncached `module_setting` query on
+    // every call) and Validator::__construct() (which re-scans every request
+    // parameter for valid UTF-8) would otherwise put the cost in linear
+    // proportion to the chart size. Each getter therefore returns its memoised
+    // value before doing either — an assignment at the return site would be too
+    // late, because the validator is built above it. The configuration is
+    // constructed per request, so a resolved value cannot go stale within its
+    // lifetime.
+
+    /**
+     * The resolved number of generations to display, or null until first resolved.
+     */
+    private ?int $generations = null;
+
+    /**
+     * The resolved detailed-date generation threshold, or null until first resolved.
+     */
+    private ?int $detailedDateGenerations = null;
+
+    /**
+     * The resolved font-scale percentage, or null until first resolved.
+     */
+    private ?int $fontScale = null;
+
+    /**
+     * Whether descendant support is active, or null until first resolved.
+     */
+    private ?bool $showDescendants = null;
+
+    /**
+     * The resolved unclamped fan degree, or null until first resolved.
+     */
+    private ?int $fanDegreeUnclamped = null;
+
+    /**
+     * Whether empty ancestor arcs are hidden, or null until first resolved.
+     */
+    private ?bool $hideEmptySegments = null;
+
+    /**
+     * Whether lineage colouring is enabled, or null until first resolved.
+     */
+    private ?bool $showFamilyColors = null;
+
+    /**
+     * Whether place names are rendered, or null until first resolved.
+     */
+    private ?bool $showPlaces = null;
+
+    /**
+     * The resolved place-format choice, or null until first resolved.
+     */
+    private ?PlaceFormatChoice $placeFormatChoice = null;
+
+    /**
+     * Whether parent marriage dates are shown, or null until first resolved.
+     */
+    private ?bool $showParentMarriageDates = null;
+
+    /**
+     * Whether highlight images are rendered, or null until first resolved.
+     */
+    private ?bool $showImages = null;
+
+    /**
+     * Whether individual names are rendered, or null until first resolved.
+     */
+    private ?bool $showNames = null;
+
+    /**
+     * Whether nicknames are shown, or null until first resolved.
+     */
+    private ?bool $showNicknames = null;
+
+    /**
+     * The resolved number of inner arcs, or null until first resolved.
+     */
+    private ?int $innerArcs = null;
+
+    /**
+     * The resolved paternal arc colour, or null until first resolved.
+     */
+    private ?string $paternalColor = null;
+
+    /**
+     * The resolved maternal arc colour, or null until first resolved.
+     */
+    private ?string $maternalColor = null;
+
     /**
      * @param ServerRequestInterface $request
      * @param AbstractModule         $module
@@ -171,7 +263,11 @@ class Configuration
      */
     public function getGenerations(): int
     {
-        return $this->validator()
+        if ($this->generations !== null) {
+            return $this->generations;
+        }
+
+        return $this->generations = $this->validator()
             ->isBetween(self::MIN_GENERATIONS, self::MAX_GENERATIONS)
             ->integer(
                 'generations',
@@ -190,7 +286,11 @@ class Configuration
      */
     public function getDetailedDateGenerations(): int
     {
-        return $this->validator()
+        if ($this->detailedDateGenerations !== null) {
+            return $this->detailedDateGenerations;
+        }
+
+        return $this->detailedDateGenerations = $this->validator()
             ->isBetween(self::MIN_DETAILED_DATE_GENERATIONS, self::MAX_GENERATIONS)
             ->integer(
                 'detailedDateGenerations',
@@ -230,7 +330,11 @@ class Configuration
      */
     public function getFontScale(): int
     {
-        return $this->validator()
+        if ($this->fontScale !== null) {
+            return $this->fontScale;
+        }
+
+        return $this->fontScale = $this->validator()
             ->isBetween(self::MIN_FONT_SCALE, self::MAX_FONT_SCALE)
             ->integer(
                 'fontScale',
@@ -248,7 +352,11 @@ class Configuration
      */
     public function getShowDescendants(): bool
     {
-        return $this->validator()
+        if ($this->showDescendants !== null) {
+            return $this->showDescendants;
+        }
+
+        return $this->showDescendants = $this->validator()
             ->boolean(
                 'showDescendants',
                 (bool) $this->module->getPreference(
@@ -262,6 +370,10 @@ class Configuration
      * Returns the opening angle of the fan in degrees (180–360). When
      * showDescendants is active, the value is clamped to 180–270 to reserve
      * angular space for the descendant section.
+     *
+     * Deliberately not memoised: it only combines two already-memoised getters
+     * with a clamp, so it reads no preference and builds no validator of its
+     * own — a property here would cache nothing that is not already cached.
      *
      * @return int
      */
@@ -284,7 +396,11 @@ class Configuration
      */
     public function getFanDegreeUnclamped(): int
     {
-        return $this->validator()
+        if ($this->fanDegreeUnclamped !== null) {
+            return $this->fanDegreeUnclamped;
+        }
+
+        return $this->fanDegreeUnclamped = $this->validator()
             ->isBetween(self::MIN_FAN_DEGREE, self::MAX_FAN_DEGREE)
             ->integer(
                 'fanDegree',
@@ -303,7 +419,11 @@ class Configuration
      */
     public function getHideEmptySegments(): bool
     {
-        return $this->validator()
+        if ($this->hideEmptySegments !== null) {
+            return $this->hideEmptySegments;
+        }
+
+        return $this->hideEmptySegments = $this->validator()
             ->boolean(
                 'hideEmptySegments',
                 (bool) $this->module->getPreference(
@@ -320,7 +440,11 @@ class Configuration
      */
     public function getShowFamilyColors(): bool
     {
-        return $this->validator()
+        if ($this->showFamilyColors !== null) {
+            return $this->showFamilyColors;
+        }
+
+        return $this->showFamilyColors = $this->validator()
             ->boolean(
                 'showFamilyColors',
                 (bool) $this->module->getPreference(
@@ -338,7 +462,11 @@ class Configuration
      */
     public function getShowPlaces(): bool
     {
-        return $this->validator()
+        if ($this->showPlaces !== null) {
+            return $this->showPlaces;
+        }
+
+        return $this->showPlaces = $this->validator()
             ->boolean(
                 'showPlaces',
                 (bool) $this->module->getPreference(
@@ -362,10 +490,14 @@ class Configuration
      */
     public function getPlaceFormatChoice(): PlaceFormatChoice
     {
+        if ($this->placeFormatChoice instanceof PlaceFormatChoice) {
+            return $this->placeFormatChoice;
+        }
+
         $stored = PlaceFormatChoice::tryFrom($this->module->getPreference('default_placeFormat', ''))
             ?? $this->legacyPlaceFormat();
 
-        return PlaceFormatChoice::tryFrom(
+        return $this->placeFormatChoice = PlaceFormatChoice::tryFrom(
             $this->validator()->string(self::PLACE_FORMAT_PARAM, $stored->value)
         ) ?? $stored;
     }
@@ -397,6 +529,11 @@ class Configuration
      * against the tree's SHOW_PEDIGREE_PLACES / SHOW_PEDIGREE_PLACES_SUFFIX
      * preferences here, because this is where the tree is available — the
      * processor stays free of webtrees configuration.
+     *
+     * Deliberately not memoised: it reads no module preference of its own — the
+     * choice comes from the memoised getPlaceFormatChoice() and the tree
+     * preferences are already cached in the Tree instance — so the per-node cost
+     * this fix targets (the uncached `module_setting` query) never arises here.
      *
      * @return PlaceFormatSpec
      */
@@ -441,7 +578,11 @@ class Configuration
      */
     public function getShowParentMarriageDates(): bool
     {
-        return $this->validator()
+        if ($this->showParentMarriageDates !== null) {
+            return $this->showParentMarriageDates;
+        }
+
+        return $this->showParentMarriageDates = $this->validator()
             ->boolean(
                 'showParentMarriageDates',
                 (bool) $this->module->getPreference(
@@ -459,13 +600,17 @@ class Configuration
      */
     public function getShowImages(): bool
     {
+        if ($this->showImages !== null) {
+            return $this->showImages;
+        }
+
         $displayMode = $this->resolveDisplayMode();
 
         if ($displayMode !== null) {
-            return in_array($displayMode, ['both', 'images'], true);
+            return $this->showImages = in_array($displayMode, ['both', 'images'], true);
         }
 
-        return $this->validator()
+        return $this->showImages = $this->validator()
             ->boolean(
                 'showImages',
                 (bool) $this->module->getPreference(
@@ -485,7 +630,11 @@ class Configuration
      */
     public function getShowNicknames(): bool
     {
-        return $this->validator()
+        if ($this->showNicknames !== null) {
+            return $this->showNicknames;
+        }
+
+        return $this->showNicknames = $this->validator()
             ->boolean(
                 'showNicknames',
                 (bool) $this->module->getPreference(
@@ -503,13 +652,17 @@ class Configuration
      */
     public function getShowNames(): bool
     {
+        if ($this->showNames !== null) {
+            return $this->showNames;
+        }
+
         $displayMode = $this->resolveDisplayMode();
 
         if ($displayMode !== null) {
-            return in_array($displayMode, ['both', 'names'], true);
+            return $this->showNames = in_array($displayMode, ['both', 'names'], true);
         }
 
-        return $this->validator()
+        return $this->showNames = $this->validator()
             ->boolean(
                 'showNames',
                 (bool) $this->module->getPreference(
@@ -546,7 +699,11 @@ class Configuration
      */
     public function getInnerArcs(): int
     {
-        return $this->validator()
+        if ($this->innerArcs !== null) {
+            return $this->innerArcs;
+        }
+
+        return $this->innerArcs = $this->validator()
             ->isBetween(self::MIN_INNER_ARCS, self::MAX_INNER_ARCS)
             ->integer(
                 'innerArcs',
@@ -600,7 +757,11 @@ class Configuration
      */
     public function getPaternalColor(): string
     {
-        return $this->validator()
+        if ($this->paternalColor !== null) {
+            return $this->paternalColor;
+        }
+
+        return $this->paternalColor = $this->validator()
             ->string(
                 'paternalColor',
                 $this->module->getPreference(
@@ -617,7 +778,11 @@ class Configuration
      */
     public function getMaternalColor(): string
     {
-        return $this->validator()
+        if ($this->maternalColor !== null) {
+            return $this->maternalColor;
+        }
+
+        return $this->maternalColor = $this->validator()
             ->string(
                 'maternalColor',
                 $this->module->getPreference(

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -32,8 +32,11 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
+use function array_filter;
 use function array_keys;
 use function array_map;
+use function count;
+use function str_contains;
 
 /**
  * Verifies that configuration handling honors defaults, validation, and
@@ -647,6 +650,101 @@ final class ConfigurationTest extends TestCase
         self::assertSame(300, $configuration->getFanDegreeUnclamped());
         // getFanDegree should return 270 (clamped)
         self::assertSame(270, $configuration->getFanDegree());
+    }
+
+    /**
+     * Pins the per-request query cost: however often the getters are called
+     * while the tree is built, each preference is read at most once.
+     */
+    #[Test]
+    public function readsEachPreferenceOnceHoweverOftenTheGettersAreCalled(): void
+    {
+        // Compares one round against ten rather than asserting a fixed number.
+        // A fixed bound would encode today's preference count and fail on an
+        // unrelated future addition while blaming memoisation. It would also pass
+        // vacuously if the getters stopped querying at all. Constant cost is the
+        // property that matters.
+        $oneRound  = $this->countPreferenceQueries(1);
+        $tenRounds = $this->countPreferenceQueries(10);
+
+        self::assertGreaterThan(0, $oneRound, 'the first round must actually read the preferences');
+        self::assertSame(
+            $oneRound,
+            $tenRounds,
+            'preference lookups are not memoised — the query cost scales with the number of nodes'
+        );
+    }
+
+    /**
+     * Runs every per-node getter $rounds times against a FRESH configuration and
+     * returns how many `module_setting` queries that produced. The instance has
+     * to be fresh per measurement — reusing one would leave it memoised from the
+     * previous round and report zero.
+     *
+     * The getter list mirrors the settings the DataFacade resolves per individual
+     * while building the tree (up to ~1023 nodes for ten generations): every
+     * getRouteToggleParams() member plus getDetailedDateGenerations() and
+     * getPlaceFormat(), which getNodeData() reads directly.
+     *
+     * @param int $rounds The number of times to invoke each getter
+     *
+     * @return int
+     */
+    private function countPreferenceQueries(int $rounds): int
+    {
+        $request       = new ServerRequest(RequestMethodInterface::METHOD_GET, '/');
+        $configuration = new Configuration($request, $this->createModuleWithPreferences([]));
+
+        $connection = DB::connection();
+        $connection->flushQueryLog();
+        $connection->enableQueryLog();
+
+        try {
+            for ($i = 0; $i < $rounds; ++$i) {
+                $configuration->getGenerations();
+                $configuration->getDetailedDateGenerations();
+                $configuration->getFontScale();
+                $configuration->getShowDescendants();
+                $configuration->getFanDegree();
+                $configuration->getFanDegreeUnclamped();
+                $configuration->getHideEmptySegments();
+                $configuration->getShowFamilyColors();
+                $configuration->getShowPlaces();
+                $configuration->getPlaceFormatChoice();
+                $configuration->getPlaceFormat();
+                $configuration->getShowParentMarriageDates();
+                $configuration->getShowImages();
+                $configuration->getShowNames();
+                $configuration->getShowNicknames();
+                $configuration->getInnerArcs();
+                $configuration->getPaternalColor();
+                $configuration->getMaternalColor();
+            }
+
+            // Counts only the preference reads the assertion talks about, so an
+            // unrelated query inside the window cannot change the verdict.
+            return count(array_filter($connection->getQueryLog(), $this->isPreferenceQuery(...)));
+        } finally {
+            $connection->disableQueryLog();
+            $connection->flushQueryLog();
+        }
+    }
+
+    /**
+     * Whether a query-log entry is a preference read.
+     *
+     * Declared as a named method with the log entry's shape rather than an
+     * inline closure: without the shape Rector wants a `(string)` cast on the
+     * query and PHPStan rejects that same cast as useless, so the two gates
+     * contradict each other.
+     *
+     * @param array{query: string, bindings: array<mixed>, time: float|null} $entry
+     *
+     * @return bool
+     */
+    private function isPreferenceQuery(array $entry): bool
+    {
+        return str_contains($entry['query'], 'module_setting');
     }
 
     /**


### PR DESCRIPTION
Closes #255.

## Summary

`Configuration`'s getters call the webtrees-core `AbstractModule::getPreference()`,
which is a bare `module_setting` query with no cache of its own. `DataFacade` reads
those getters from inside the per-individual recursion, so the preference query count
grew with the number of rendered nodes. This memoises each per-node getter so every
preference is read at most once per request, regardless of tree size — the same fix
`webtrees-descendants-chart` already carries (#115).

## What changed

- **16 per-node getters memoised.** Each gets a nullable property and an early-return
  guard placed *before* `validator()` is built. The guard has to sit there rather than
  wrapping the return expression in `??=`: `Validator::__construct()` walks every request
  parameter checking UTF-8, so a `??=` would leave that construction cost in place and
  only short-circuit the inside of the assignment.
- **Two getters deliberately left unmemoised**, with in-code reasons: `getFanDegree()`
  only clamps two already-memoised getters, and `getPlaceFormat()` derives from the
  memoised `getPlaceFormatChoice()` plus the tree's own cached preferences — neither
  issues a `module_setting` read.
- Memoisation cannot leak across request methods: `validator()` picks query-vs-body
  purely from the request method, and the request is `readonly`, so each value is
  resolved under the one validator that matches the request.

## Testing

The test asserts *scaling*, not a fixed number: it runs every per-node getter once, then
ten times, on fresh `Configuration` instances, counts only `module_setting` queries, and
asserts the two counts are equal with a `> 0` lower bound. Red before the fix
(21 vs 210 — linear in node count), green after (constant). An absolute upper bound was
deliberately avoided — it would encode today's preference count and break when an
unrelated preference is added later.

`composer ci:test` green across the PHP support matrix (8.3 / 8.4 / 8.5): PHPUnit 40
tests, jest 105, PHPStan max, Rector, CGL and jscpd clean.

Related: `webtrees-pedigree-chart#129` tracks the same defect there.
