### PR TITLE
GH-253: Fix unlink-base deleting an unrestorable module-base

### DIFF
--- a/Make/dev.mk
+++ b/Make/dev.mk
@@ -18,8 +18,8 @@ link-base: .logo ## Symlink .build/vendor/.../webtrees-module-base to the siblin
 		echo -e "${FRED} ✘${FRESET} Expected sibling clone at $(MODULE_BASE_CLONE)"; \
 		exit 1; \
 	fi
-	@rm -rf $(MODULE_BASE_VENDOR)
-	@ln -s "$$(cd $(MODULE_BASE_CLONE) && pwd)" $(MODULE_BASE_VENDOR)
+	@rm -rf "$(MODULE_BASE_VENDOR)"
+	@ln -s "$$(cd $(MODULE_BASE_CLONE) && pwd)" "$(MODULE_BASE_VENDOR)"
 	@echo -e "${FGREEN} ✔${FRESET} Symlinked $(MODULE_BASE_VENDOR) → $$(cd $(MODULE_BASE_CLONE) && pwd)"
 	@echo -e "${FYELLOW}   Note:${FRESET} composer install/update will replace this symlink with a fresh checkout."
 

--- a/Make/dev.mk
+++ b/Make/dev.mk
@@ -23,7 +23,16 @@ link-base: .logo ## Symlink .build/vendor/.../webtrees-module-base to the siblin
 	@echo -e "${FGREEN} ✔${FRESET} Symlinked $(MODULE_BASE_VENDOR) → $$(cd $(MODULE_BASE_CLONE) && pwd)"
 	@echo -e "${FYELLOW}   Note:${FRESET} composer install/update will replace this symlink with a fresh checkout."
 
-unlink-base: .logo ## Restore .build/vendor/.../webtrees-module-base from composer.
-	@rm -rf $(MODULE_BASE_VENDOR)
-	@$(COMPOSE_RUN) composer install --quiet
-	@echo -e "${FGREEN} ✔${FRESET} Restored $(MODULE_BASE_VENDOR) from composer."
+unlink-base: .logo ## Remove the module-base dev symlink; print how to restore the composer checkout.
+	@if [ ! -L "$(MODULE_BASE_VENDOR)" ]; then \
+		if [ -e "$(MODULE_BASE_VENDOR)" ]; then \
+			echo -e "${FYELLOW} ⚠${FRESET} $(MODULE_BASE_VENDOR) is a real checkout, not a symlink — leaving it untouched."; \
+		else \
+			echo -e "${FYELLOW} ⚠${FRESET} $(MODULE_BASE_VENDOR) does not exist — nothing to unlink."; \
+		fi; \
+	else \
+		rm -f "$(MODULE_BASE_VENDOR)"; \
+		echo -e "${FGREEN} ✔${FRESET} Removed the dev symlink $(MODULE_BASE_VENDOR)."; \
+		echo -e "${FYELLOW}   Restore the composer checkout by running composer install for this module"; \
+		echo -e "   through the webtrees buildbox (these repos ship no PHP/composer container of their own).${FRESET}"; \
+	fi


### PR DESCRIPTION
Closes #253.

## The bug

`unlink-base` ran `rm -rf` on the vendored `webtrees-module-base` and then tried to
restore it with `composer install` through `COMPOSE_RUN` — the `node` service, which
has neither `composer` nor `php`. The restore therefore always failed, while the
delete had already happened, leaving the module without the dependency the target
advertises it will restore. The `@` prefixes and `--quiet` hid everything but the
failing exit status.

## The fix

Guard on the symlink: only remove `MODULE_BASE_VENDOR` when it actually is a symlink
(what `link-base` creates), and with `rm -f`, not `rm -rf`. A real composer checkout
is then left untouched instead of deleted-and-unrestorable. The broken composer call
is dropped; the target prints how to restore through the buildbox, which is where PHP
runs for these repos (they ship no PHP/composer container of their own).

## Verified

- Real checkout present → target leaves it intact ("is a real checkout … untouched").
- A symlink → removed, its clone target survives.
- Nothing present → safe no-op.

## Note

The same broken target exists byte-identically in `webtrees-pedigree-chart` and
`webtrees-descendants-chart`, and `webtrees-statistics` carries a different, safer
variant (guards `composer` on the host PATH). All four are being unified onto this
canonical, container-agnostic form so the tooling is identical again.
