### PR TITLE
GH-281: Adopt module-base 3.0.1 NameAbbreviation enum

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Module.php (entry point, registers routes)
 - **Configuration.php** — Reads form parameters from request (POST/GET) with user preference fallback.
 - **Facade/DataFacade.php** — Builds hierarchical Node tree. `buildTimespan()` assembles date+place lines from structured event data via `buildEventLine()`. `getUpdateRoute()` generates AJAX URL for person-click navigation.
 - **Model/Node, NodeData** — Tree node with JSON serialization for D3.
-- **Shared classes from [`magicsunday/webtrees-module-base`](https://github.com/magicsunday/webtrees-module-base)** (composer dependency `^1.1`):
+- **Shared classes from [`magicsunday/webtrees-module-base`](https://github.com/magicsunday/webtrees-module-base)** (composer dependency `^3.0.1`):
   - `Processor/DateProcessor` — generation-aware date formatting; DataFacade calls the `getFormatted*` methods (compact DD.MM.YYYY) rather than the locale-aware legacy methods.
   - `Processor/NameProcessor`, `Processor/ImageProcessor`, `Processor/PlaceProcessor` — name/image/place extraction.
   - `Model/Symbols` — backed enum for genealogical symbols (Birth ★, Death †, MarriageDateUnknown sentinel).

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "ext-dom": "*",
         "ext-json": "*",
         "fisharebest/webtrees": "~2.2.0",
-        "magicsunday/webtrees-module-base": "^3.0",
+        "magicsunday/webtrees-module-base": "^3.0.1",
         "magicsunday/webtrees-module-installer-plugin": "^2.0"
     },
     "require-dev": {

--- a/resources/lang/af/messages.po
+++ b/resources/lang/af/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "'n Waaierdiagram van 'n persoon se voorouers."
 
@@ -118,11 +118,11 @@ msgstr "Voer as PNG uit"
 msgid "Export as SVG"
 msgstr "Voer as SVG uit"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Waaierdiagram"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "%s se waaierdiagram"
@@ -216,7 +216,7 @@ msgstr ""
 msgid "Move the chart"
 msgstr "Skuif die diagram"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Beweeg die aansig met twee vingers"
 
@@ -347,7 +347,7 @@ msgstr "Wissel tussen volskerm en normale aansig"
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Gebruik Ctrl + rol om te vergroot"
 

--- a/resources/lang/cs/messages.po
+++ b/resources/lang/cs/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Vějíř předků osoby."
 
@@ -117,11 +117,11 @@ msgstr "Exportovat jako PNG"
 msgid "Export as SVG"
 msgstr "Exportovat jako SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Vějířový diagram"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Vějíř předků osoby %s"
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Move the chart"
 msgstr "Přesunout diagram"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Přemístit pohled dvěma prsty"
 
@@ -346,7 +346,7 @@ msgstr "Přepnout mezi celou obrazovkou a normálním zobrazením"
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Pomocí Ctrl + kolečko zvětšit pohled"
 

--- a/resources/lang/de/messages.po
+++ b/resources/lang/de/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Ein Fächerdiagramm der Vorfahren einer Person."
 
@@ -118,11 +118,11 @@ msgstr "Als PNG exportieren"
 msgid "Export as SVG"
 msgstr "Als SVG exportieren"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Fächerdiagramm"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Fächerdiagramm von %s"
@@ -221,7 +221,7 @@ msgstr ""
 msgid "Move the chart"
 msgstr "Diagramm verschieben"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Verschieben der Ansicht mit zwei Fingern"
 
@@ -352,7 +352,7 @@ msgstr "Zwischen Vollbildmodus und normaler Ansicht umschalten"
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Verwende Strg+Scrollen zum Zoomen der Ansicht"
 

--- a/resources/lang/en-GB/messages.po
+++ b/resources/lang/en-GB/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "A fan chart of an individual’s ancestors."
 
@@ -118,11 +118,11 @@ msgstr "Export as PNG"
 msgid "Export as SVG"
 msgstr "Export as SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Fan chart"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Fan chart of %s"
@@ -219,7 +219,7 @@ msgstr "Modules"
 msgid "Move the chart"
 msgstr "Move the chart"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Move the view with two fingers"
 
@@ -349,7 +349,7 @@ msgstr "Switch between full screen mode and normal view"
 msgid "The preferences for the module “%s” have been updated."
 msgstr "The preferences for the module “%s” have been updated."
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Use Ctrl+Scroll wheel to zoom the chart"
 

--- a/resources/lang/en-US/messages.po
+++ b/resources/lang/en-US/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "A fan chart of an individual’s ancestors."
 
@@ -118,11 +118,11 @@ msgstr "Export as PNG"
 msgid "Export as SVG"
 msgstr "Export as SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Fan chart"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Fan chart of %s"
@@ -219,7 +219,7 @@ msgstr "Modules"
 msgid "Move the chart"
 msgstr "Move the chart"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Move the view with two fingers"
 
@@ -349,7 +349,7 @@ msgstr "Switch between full screen mode and normal view"
 msgid "The preferences for the module “%s” have been updated."
 msgstr "The preferences for the module “%s” have been updated."
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Use Ctrl + scroll to zoom in the view"
 

--- a/resources/lang/es/messages.po
+++ b/resources/lang/es/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Un diagrama de abanico de los antepasados de un individuo."
 
@@ -119,11 +119,11 @@ msgstr "Exportar como PNG"
 msgid "Export as SVG"
 msgstr "Exportar como SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Diagrama en abanico"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Diagrama en abanico de %s"
@@ -218,7 +218,7 @@ msgstr ""
 msgid "Move the chart"
 msgstr "Mover el diagrama"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Mueve la vista con dos dedos"
 
@@ -351,7 +351,7 @@ msgstr "Cambiar entre pantalla completa y vista normal"
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Use Ctrl + scroll para acercar la vista"
 

--- a/resources/lang/fi/messages.po
+++ b/resources/lang/fi/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Viuhkakaavio henkilön esi-isistä."
 
@@ -118,11 +118,11 @@ msgstr "Vie PNG-muodossa"
 msgid "Export as SVG"
 msgstr "Vie SVG-muodossa"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Esipolvi-viuhkakaavio"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Esipolvi-viuhkakaavio - %s"
@@ -217,7 +217,7 @@ msgstr ""
 msgid "Move the chart"
 msgstr "Siirrä kaaviota"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Siirrä näkymä kahdella sormella"
 
@@ -348,7 +348,7 @@ msgstr "Vaihda kokoruudun ja normaalinäkymän välillä"
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Zoomaa näkymää käyttämällä ohjausnäppäintä (Ctrl) + rullauslaitetta"
 

--- a/resources/lang/fr/messages.po
+++ b/resources/lang/fr/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Un éventail des ancêtres d'un individu."
 
@@ -120,11 +120,11 @@ msgstr "Exporter au format PNG"
 msgid "Export as SVG"
 msgstr "Exporter au format SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Éventail des ancêtres"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Éventail des ancêtres de %s"
@@ -219,7 +219,7 @@ msgstr ""
 msgid "Move the chart"
 msgstr "Déplacer le diagramme"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Déplacer la vue avec deux doigts"
 
@@ -352,7 +352,7 @@ msgstr "Basculer entre le plein écran et la vue normale"
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Utiliser Ctrl + molette pour zoomer dans la vue"
 

--- a/resources/lang/he/messages.po
+++ b/resources/lang/he/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "תרשים מעריצים של אבותיו של אדם."
 
@@ -117,11 +117,11 @@ msgstr "ייצא כ-PNG"
 msgid "Export as SVG"
 msgstr "ייצא כ-SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "תרשים מניפה של אבות"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "תרשים מניפה של אבות של %s"
@@ -214,7 +214,7 @@ msgstr ""
 msgid "Move the chart"
 msgstr "הזזת התרשים"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "הזז את התצוגה בשתי אצבעות"
 
@@ -343,7 +343,7 @@ msgstr "החלף בין מסך מלא לתצוגה רגילה"
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "השתמש ב- Ctrl + גלילה כדי להגדיל את התצוגה"
 

--- a/resources/lang/hi/messages.po
+++ b/resources/lang/hi/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "किसी व्यक्ती के पूर्वजों का एक फैन चार्ट।"
 
@@ -115,11 +115,11 @@ msgstr "PNG निकालें"
 msgid "Export as SVG"
 msgstr "SVG निकालें"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "फैन चार्ट"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "%s का फैन चार्ट"
@@ -213,7 +213,7 @@ msgstr ""
 msgid "Move the chart"
 msgstr "चार्ट को स्थानांतरित करें"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "दो उंगलियों से दृश्य को स्थानांतरित करें"
 
@@ -342,7 +342,7 @@ msgstr "पूर्ण स्क्रीन और सामान्य द�
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Ctrl + Scroll से ज़ूम इन करें"
 

--- a/resources/lang/is/messages.po
+++ b/resources/lang/is/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Skífurit yfir forfeður einstaklings."
 
@@ -118,11 +118,11 @@ msgstr "Flytja út sem PNG"
 msgid "Export as SVG"
 msgstr "Flytja út sem SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Forfeðraskífa"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Forfeðraskífa fyrir %s"
@@ -216,7 +216,7 @@ msgstr "Einingar"
 msgid "Move the chart"
 msgstr "Færa línuritið"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Færðu yfirlitið með tveimur fingrum"
 
@@ -347,7 +347,7 @@ msgstr "Skiptu á milli fullskjás og venjulegs skjás"
 msgid "The preferences for the module “%s” have been updated."
 msgstr "Kjörstillingar fyrir eininguna “%s” hafa verið uppfærðar."
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Notaðu Ctrl + skruna til að þysja í ættartrénu"
 

--- a/resources/lang/it/messages.po
+++ b/resources/lang/it/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Un grafico a ventaglio degli antenati di una persona."
 
@@ -119,11 +119,11 @@ msgstr "Esporta come PNG"
 msgid "Export as SVG"
 msgstr "Esporta come SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Grafico a ventaglio"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Grafico a ventaglio di %s"
@@ -217,7 +217,7 @@ msgstr "Moduli"
 msgid "Move the chart"
 msgstr "Sposta il diagramma"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Spostare la vista"
 
@@ -349,7 +349,7 @@ msgstr "Passa dalla modalità a schermo intero alla visualizzazione normale"
 msgid "The preferences for the module “%s” have been updated."
 msgstr "Le preferenze per il modulo \"%s\" sono state aggiornate."
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Usare Ctrl + scorrimento per ingrandire la vista"
 

--- a/resources/lang/nb/messages.po
+++ b/resources/lang/nb/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Et viftediagram over en persons aner."
 
@@ -117,11 +117,11 @@ msgstr "Eksporter som PNG"
 msgid "Export as SVG"
 msgstr "Eksporter som SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Viftediagram"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Viftediagram til %s"
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Move the chart"
 msgstr "Flytt diagrammet"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Bruk to fingre for å flytte utsnitt"
 
@@ -346,7 +346,7 @@ msgstr "Bytt mellom fullskjerm og normal visning"
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Bruk Ctrl + scroll for zoom"
 

--- a/resources/lang/nl/messages.po
+++ b/resources/lang/nl/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Een waaierdiagram met de voorouders van een persoon."
 
@@ -118,11 +118,11 @@ msgstr "Exporteren als PNG"
 msgid "Export as SVG"
 msgstr "Exporteren als SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Waaierdiagram"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Waaierdiagram van %s"
@@ -221,7 +221,7 @@ msgstr "Modules"
 msgid "Move the chart"
 msgstr "Diagram verplaatsen"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Verplaats de weergave met twee vingers"
 
@@ -352,7 +352,7 @@ msgstr "Schakelen tussen volledig scherm en normale weergave"
 msgid "The preferences for the module “%s” have been updated."
 msgstr "De voorkeuren voor de module \"%s\" zijn bijgewerkt."
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Gebruik Ctrl + scroll om in te zoomen op de weergave"
 

--- a/resources/lang/nn/messages.po
+++ b/resources/lang/nn/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Eit viftediagram over ein person sine anar."
 
@@ -117,11 +117,11 @@ msgstr "Eksporter som PNG"
 msgid "Export as SVG"
 msgstr "Eksporter som SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Viftediagram"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Viftediagram til %s"
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Move the chart"
 msgstr "Flytt diagrammet"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Bruk to fingrar for å flytte utsnitt"
 
@@ -345,7 +345,7 @@ msgstr "Byt mellom fullskjerm og normal visning"
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Bruk Ctrl + scroll for zoom"
 

--- a/resources/lang/pt/messages.po
+++ b/resources/lang/pt/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Diagrama em leque dos ascendentes de um indivíduo."
 
@@ -118,11 +118,11 @@ msgstr "Exportar como PNG"
 msgid "Export as SVG"
 msgstr "Exportar como SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Diagrama em leque"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Diagrama em leque de %s"
@@ -216,7 +216,7 @@ msgstr "Módulos"
 msgid "Move the chart"
 msgstr "Mover o diagrama"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Mover a vista com dois dedos"
 
@@ -347,7 +347,7 @@ msgstr "Alternar entre vista em ecrã completo e vista normal"
 msgid "The preferences for the module “%s” have been updated."
 msgstr "As preferências do módulo \"%s\" foram atualizadas."
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Usar Ctrl + roda do rato para aproximar ou afastar"
 

--- a/resources/lang/ru/messages.po
+++ b/resources/lang/ru/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Веерный график персоны."
 
@@ -118,11 +118,11 @@ msgstr "Экспорт в PNG"
 msgid "Export as SVG"
 msgstr "Экспорт в SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Веерный график"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Веерный график для %s"
@@ -216,7 +216,7 @@ msgstr ""
 msgid "Move the chart"
 msgstr "Переместить диаграмму"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Перемещайте, используя два пальца"
 
@@ -347,7 +347,7 @@ msgstr "Переключение между полноэкранным и обы
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Используйте Ctrl + колёсико мыши, чтобы увеличить"
 

--- a/resources/lang/sl/messages.po
+++ b/resources/lang/sl/messages.po
@@ -21,7 +21,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Pahljačasti diagram posameznikovih prednikov."
 
@@ -120,11 +120,11 @@ msgstr "Izvozi kot PNG"
 msgid "Export as SVG"
 msgstr "Izvozi kot SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Pahljačasti diagram"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Pahljačasti diagram osebe %s"
@@ -218,7 +218,7 @@ msgstr "Moduli"
 msgid "Move the chart"
 msgstr "Premakni diagram"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Premakni pogled z dvema prstoma"
 
@@ -348,7 +348,7 @@ msgstr "Preklopi med celozaslonskim in običajnim načinom"
 msgid "The preferences for the module “%s” have been updated."
 msgstr "Nastavitve modula “%s” so posodobljene."
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Uporabi Ctrl+Scroll kolesce za povečavo diagrama"
 

--- a/resources/lang/sr-Latn/messages.po
+++ b/resources/lang/sr-Latn/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Lepeza grafikon predaka pojedinca."
 
@@ -117,11 +117,11 @@ msgstr "Izvezi kao PNG"
 msgid "Export as SVG"
 msgstr "Izvezi kao SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Lepeza grafikon"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Lepeza grafikon %s"
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Move the chart"
 msgstr "Pomeri dijagram"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Pomeranje prikaza pomoću dva prsta"
 
@@ -346,7 +346,7 @@ msgstr "Prebacivanje između celog ekrana i običnog prikaza"
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Koristi CTRL+ skrol za zumiranje u prikazu"
 

--- a/resources/lang/sr/messages.po
+++ b/resources/lang/sr/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Лепеза графикон појединчевих предака."
 
@@ -117,11 +117,11 @@ msgstr "Извези у PNG"
 msgid "Export as SVG"
 msgstr "Извези као SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Лепеза графикон"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Лепеза графикон %s"
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Move the chart"
 msgstr "Помери дијаграм"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Померите поглед са два прста"
 
@@ -346,7 +346,7 @@ msgstr "Пребацивање између целог екрана и обич�
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Користите CTRL + скрол да бисте зумирали приказ"
 

--- a/resources/lang/sv/messages.po
+++ b/resources/lang/sv/messages.po
@@ -20,7 +20,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Ett solfjäderdiagram med en persons förfäder."
 
@@ -119,11 +119,11 @@ msgstr "Exportera som PNG"
 msgid "Export as SVG"
 msgstr "Exportera som SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Solfjäderdiagram"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Solfjäderdiagram för %s"
@@ -217,7 +217,7 @@ msgstr ""
 msgid "Move the chart"
 msgstr "Flytta diagrammet"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Flytta vyn med två fingrar"
 
@@ -348,7 +348,7 @@ msgstr "Växla mellan helskärm och normal vy"
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Använd Ctrl + rullen för att zooma in vyn"
 

--- a/resources/lang/uk/messages.po
+++ b/resources/lang/uk/messages.po
@@ -19,7 +19,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Віялова діаграма предків особи."
 
@@ -118,11 +118,11 @@ msgstr "Експорт в PNG"
 msgid "Export as SVG"
 msgstr "Експорт в SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Віяловий графік"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Віяловий графік для %s"
@@ -216,7 +216,7 @@ msgstr ""
 msgid "Move the chart"
 msgstr "Перемістити діаграму"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Переміщуйте зображення двома пальцями"
 
@@ -347,7 +347,7 @@ msgstr "Перемикання між повноекранним і звичай
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Використовуйте Ctrl + коліщатко миші для збільшення зображення"
 

--- a/resources/lang/vi/messages.po
+++ b/resources/lang/vi/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "Biểu đồ cá nhân Tổ tiên"
 
@@ -117,11 +117,11 @@ msgstr "Xuất định dạng PNG"
 msgid "Export as SVG"
 msgstr "Xuất định dạng SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "Biểu đồ hình quạt"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Biểu đồ hình quạt của %s"
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Move the chart"
 msgstr "Di chuyển biểu đồ"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "Di chuyển tầm nhìn bằng hai ngón tay"
 
@@ -345,7 +345,7 @@ msgstr "Chuyển giữa toàn màn hình và xem bình thường"
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "Kết hợp Ctrl + scroll để thu phóng biểu đồ"
 

--- a/resources/lang/zh-Hans/messages.po
+++ b/resources/lang/zh-Hans/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "一种以扇形样式显示个人祖先的图表。"
 
@@ -113,11 +113,11 @@ msgstr "导出为 PNG"
 msgid "Export as SVG"
 msgstr "导出为 SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "扇形图"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "%s的扇形图"
@@ -209,7 +209,7 @@ msgstr ""
 msgid "Move the chart"
 msgstr "移动图表"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "用两个手指移动视图"
 
@@ -335,7 +335,7 @@ msgstr "切换全屏与普通视图"
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "按住Ctrl键滚动鼠标滚轮放大缩小"
 

--- a/resources/lang/zh-Hant/messages.po
+++ b/resources/lang/zh-Hant/messages.po
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: src\n"
 "X-Poedit-SearchPath-1: resources/views\n"
 
-#: src/Module.php:136
+#: src/Module.php:135
 msgid "A fan chart of an individual’s ancestors."
 msgstr "一種以扇形樣式顯示個人祖先的圖表。"
 
@@ -113,11 +113,11 @@ msgstr "匯出為 PNG"
 msgid "Export as SVG"
 msgstr "匯出為 SVG"
 
-#: src/Module.php:124 src/Module.php:237
+#: src/Module.php:123 src/Module.php:236
 msgid "Fan chart"
 msgstr "扇形圖"
 
-#: src/Module.php:234 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "%s的扇形圖"
@@ -209,7 +209,7 @@ msgstr ""
 msgid "Move the chart"
 msgstr "移動圖表"
 
-#: src/Module.php:262
+#: src/Module.php:260
 msgid "Move the view with two fingers"
 msgstr "用兩個手指移動視圖"
 
@@ -335,7 +335,7 @@ msgstr "切換全螢幕與一般檢視"
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""
 
-#: src/Module.php:261
+#: src/Module.php:259
 msgid "Use Ctrl + scroll to zoom in the view"
 msgstr "按住Ctrl鍵滾動鼠標滾輪放大縮小"
 

--- a/resources/views/modules/fan-chart/config.phtml
+++ b/resources/views/modules/fan-chart/config.phtml
@@ -76,7 +76,7 @@ use MagicSunday\Webtrees\FanChart\Configuration;
                     <?php echo view('components/select', [
                         'name'     => 'nameAbbreviation',
                         'id'       => 'nameAbbreviation',
-                        'selected' => $configuration->getNameAbbreviation(),
+                        'selected' => $configuration->getNameAbbreviation()->value,
                         'options'  => $configuration->getNameAbbreviationList(),
                         'class'    => 'form-control-sm',
                     ]);

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -801,34 +801,33 @@ class Configuration
     public function getNameAbbreviationList(): array
     {
         return [
-            NameAbbreviation::AUTO    => I18N::translate("Automatic (based on tree's surname tradition)"),
-            NameAbbreviation::GIVEN   => I18N::translate('Abbreviate given names first'),
-            NameAbbreviation::SURNAME => I18N::translate('Abbreviate surnames first'),
+            NameAbbreviation::Auto->value    => I18N::translate("Automatic (based on tree's surname tradition)"),
+            NameAbbreviation::Given->value   => I18N::translate('Abbreviate given names first'),
+            NameAbbreviation::Surname->value => I18N::translate('Abbreviate surnames first'),
         ];
     }
 
     /**
-     * Returns the name-abbreviation strategy as stored. One of {@see
-     * NameAbbreviation::AUTO}, GIVEN or SURNAME. The chart-render path resolves
-     * AUTO to GIVEN/SURNAME via the tree's SURNAME_TRADITION before serialising
-     * to the JS config — see {@see Module::getChartParameters()}.
+     * Returns the configured name-abbreviation strategy. A stale or invalid
+     * stored value falls back to {@see NameAbbreviation::Auto} rather than being
+     * passed through. The chart-render path resolves Auto to Given/Surname via
+     * the tree's SURNAME_TRADITION before serialising to the JS config — see
+     * {@see Module::getChartParameters()}.
      *
-     * @return string
+     * @return NameAbbreviation
      */
-    public function getNameAbbreviation(): string
+    public function getNameAbbreviation(): NameAbbreviation
     {
         $value = $this->validator()
             ->string(
                 'nameAbbreviation',
                 $this->module->getPreference(
                     'default_nameAbbreviation',
-                    NameAbbreviation::AUTO
+                    NameAbbreviation::Auto->value
                 )
             );
 
-        return in_array($value, NameAbbreviation::CHOICES, true)
-            ? $value
-            : NameAbbreviation::AUTO;
+        return NameAbbreviation::tryFrom($value) ?? NameAbbreviation::Auto;
     }
 
     /**

--- a/src/Module.php
+++ b/src/Module.php
@@ -33,7 +33,6 @@ use MagicSunday\Webtrees\FanChart\Facade\DataFacade;
 use MagicSunday\Webtrees\FanChart\Traits\ModuleChartTrait;
 use MagicSunday\Webtrees\FanChart\Traits\ModuleConfigTrait;
 use MagicSunday\Webtrees\ModuleBase\Contract\ModuleAssetUrlInterface;
-use MagicSunday\Webtrees\ModuleBase\Model\NameAbbreviation;
 use MagicSunday\Webtrees\ModuleBase\Traits\ModuleCustomTrait;
 use Override;
 use Psr\Container\ContainerExceptionInterface;
@@ -253,10 +252,9 @@ class Module extends FanChartModule implements ModuleAssetUrlInterface, ModuleCu
             'rtl'              => I18N::direction() === 'rtl',
             'showImages'       => $this->showImages($individual),
             'showSilhouettes'  => $this->showSilhouettes($individual),
-            'nameAbbreviation' => NameAbbreviation::resolve(
-                $this->configuration->getNameAbbreviation(),
-                $individual->tree()->getPreference('SURNAME_TRADITION')
-            ),
+            'nameAbbreviation' => $this->configuration->getNameAbbreviation()
+                ->resolve($individual->tree()->getPreference('SURNAME_TRADITION'))
+                ->value,
             'labels' => [
                 'zoom' => I18N::translate('Use Ctrl + scroll to zoom in the view'),
                 'move' => I18N::translate('Move the view with two fingers'),

--- a/src/Traits/ModuleConfigTrait.php
+++ b/src/Traits/ModuleConfigTrait.php
@@ -138,7 +138,7 @@ trait ModuleConfigTrait
         );
         $this->setPreference(
             'default_nameAbbreviation',
-            $configuration->getNameAbbreviation()
+            $configuration->getNameAbbreviation()->value
         );
 
         FlashMessages::addMessage(

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -24,6 +24,7 @@ use Illuminate\Database\Schema\Blueprint;
 use MagicSunday\Webtrees\FanChart\Configuration;
 use MagicSunday\Webtrees\FanChart\Facade\DataFacade;
 use MagicSunday\Webtrees\FanChart\Module;
+use MagicSunday\Webtrees\ModuleBase\Model\NameAbbreviation;
 use MagicSunday\Webtrees\ModuleBase\Model\PlaceFormatChoice;
 use MagicSunday\Webtrees\ModuleBase\Model\PlaceStyle;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -191,6 +192,141 @@ final class ConfigurationTest extends TestCase
         self::assertSame(
             PlaceFormatChoice::CityIso3,
             (new Configuration($request, $module))->getPlaceFormatChoice()
+        );
+    }
+
+    /**
+     * The stored name-abbreviation preference is converted to its typed case at
+     * the boundary, so a valid stored value round-trips to the matching enum
+     * case.
+     */
+    #[Test]
+    public function nameAbbreviationReturnsTheStoredCase(): void
+    {
+        $request = new ServerRequest(RequestMethodInterface::METHOD_GET, '/');
+        $module  = $this->createModuleWithPreferences([
+            'default_nameAbbreviation' => 'SURNAME',
+        ]);
+
+        self::assertSame(
+            NameAbbreviation::Surname,
+            (new Configuration($request, $module))->getNameAbbreviation()
+        );
+    }
+
+    /**
+     * A stored value outside the enum's backing set (a stale or typo'd
+     * preference) no longer propagates silently: tryFrom() rejects it and the
+     * getter falls back to Auto instead of passing the raw string through — the
+     * regression the old string-in/string-out shape allowed.
+     */
+    #[Test]
+    public function nameAbbreviationFallsBackToAutoForAnUnknownStoredValue(): void
+    {
+        $request = new ServerRequest(RequestMethodInterface::METHOD_GET, '/');
+        $module  = $this->createModuleWithPreferences([
+            'default_nameAbbreviation' => 'not-a-strategy',
+        ]);
+
+        self::assertSame(
+            NameAbbreviation::Auto,
+            (new Configuration($request, $module))->getNameAbbreviation()
+        );
+    }
+
+    /**
+     * Absent both a request parameter and a stored preference, the strategy
+     * defaults to Auto.
+     */
+    #[Test]
+    public function nameAbbreviationDefaultsToAutoWhenUnset(): void
+    {
+        $request = new ServerRequest(RequestMethodInterface::METHOD_GET, '/');
+        $module  = $this->createModuleWithPreferences([]);
+
+        self::assertSame(
+            NameAbbreviation::Auto,
+            (new Configuration($request, $module))->getNameAbbreviation()
+        );
+    }
+
+    /**
+     * A POSTed nameAbbreviation parameter is validated through validator() and
+     * takes precedence over the stored preference.
+     */
+    #[Test]
+    public function nameAbbreviationReadsThePostedParameter(): void
+    {
+        $request = new ServerRequest(
+            RequestMethodInterface::METHOD_POST,
+            '/',
+            [],
+            null,
+            '1.1'
+        );
+
+        $request = $request->withParsedBody([
+            'nameAbbreviation' => 'GIVEN',
+        ]);
+
+        $module = $this->createModuleWithPreferences([
+            'default_nameAbbreviation' => 'SURNAME',
+        ]);
+
+        self::assertSame(
+            NameAbbreviation::Given,
+            (new Configuration($request, $module))->getNameAbbreviation()
+        );
+    }
+
+    /**
+     * A POSTed value takes precedence over the stored preference, so an invalid
+     * POSTed value falls back to Auto rather than silently keeping a valid
+     * stored strategy — the posted (invalid) value wins the precedence, then
+     * tryFrom() rejects it.
+     */
+    #[Test]
+    public function nameAbbreviationFallsBackToAutoForAnInvalidPostedValue(): void
+    {
+        $request = new ServerRequest(
+            RequestMethodInterface::METHOD_POST,
+            '/',
+            [],
+            null,
+            '1.1'
+        );
+
+        $request = $request->withParsedBody([
+            'nameAbbreviation' => 'not-a-strategy',
+        ]);
+
+        $module = $this->createModuleWithPreferences([
+            'default_nameAbbreviation' => 'SURNAME',
+        ]);
+
+        self::assertSame(
+            NameAbbreviation::Auto,
+            (new Configuration($request, $module))->getNameAbbreviation()
+        );
+    }
+
+    /**
+     * The admin dropdown is keyed by the persisted enum backing values so the
+     * posted selection round-trips through tryFrom() on the way back in.
+     */
+    #[Test]
+    public function nameAbbreviationListIsKeyedByTheEnumBackingValues(): void
+    {
+        $request = new ServerRequest(RequestMethodInterface::METHOD_GET, '/');
+        $module  = $this->createModuleWithPreferences([]);
+
+        self::assertSame(
+            [
+                NameAbbreviation::Auto->value,
+                NameAbbreviation::Given->value,
+                NameAbbreviation::Surname->value,
+            ],
+            array_keys((new Configuration($request, $module))->getNameAbbreviationList())
         );
     }
 


### PR DESCRIPTION
Closes #281.

`magicsunday/webtrees-module-base` 3.0.1 turns `NameAbbreviation` from a class with `AUTO`/`GIVEN`/`SURNAME` string constants, a hand-maintained `CHOICES` array and a static string-in/string-out `resolve()` into a backed enum with an instance `resolve()`. This migrates the module to the new shape.

## Changes

- `Configuration::getNameAbbreviation()` converts at the boundary (`tryFrom()` once where the preference/request value is read) and returns the `NameAbbreviation` case, falling back to `Auto` for a stale or invalid value instead of passing the raw string through. Mirrors the existing `getPlaceFormatChoice()` enum getter.
- `getNameAbbreviationList()` keys the admin dropdown by the enum backing values.
- The three string sinks append `->value`: the resolved JS chart parameter in `Module::getChartParameters()`, the persisted preference in `ModuleConfigTrait`, and the selected option in `config.phtml`.
- module-base floor raised `^3.0` → `^3.0.1` (the migrated code needs the enum API; 3.0.0 still ships the old class); the version noted in `AGENTS.md` synced.
- The `.po` diff is a source-location (`#:`) resync only — no msgid/msgstr changes, 0 fuzzy.

## Tests

Six `ConfigurationTest` cases pin the boundary conversion: stored-case round-trip, unknown stored-value fallback to `Auto`, unset default, POST precedence, invalid POSTed value falling back to `Auto` over a valid stored preference, and the list keying.

`composer ci:test` green on the PHP 8.4 and 8.5 buildbox legs against stable webtrees 2.2.6 + module-base 3.0.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the name-abbreviation setting in fan chart configuration.
  * Saved selections now display correctly in the administration interface.
  * Missing or invalid settings safely fall back to automatic name abbreviation.
  * Fan charts consistently apply the selected name-abbreviation preference.

* **Documentation**
  * Refreshed translation catalog references without changing any translated text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->