### PR TITLE
GH-285: Adopt the shared coding-standard package and the reusable php-quality workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,17 @@ permissions:
     contents: read
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
+    # The PHP gates come from the shared reusable so the canonical step list lives
+    # in one place. Copy-paste detection stays below: jscpd is a Node tool and
+    # needs this repository's JS lane.
+    php:
+        uses: magicsunday/.github/.github/workflows/php-quality.yml@main
+        permissions:
+            contents: read
 
-        strategy:
-            fail-fast: false
-            matrix:
-                php: ['8.3', '8.4', '8.5']
+    js:
+        name: JS and release zip
+        runs-on: ubuntu-latest
 
         steps:
             - id: checkout
@@ -32,30 +36,14 @@ jobs:
                   cache: npm
 
             - id: setup_php
-              name: Set up PHP version ${{ matrix.php }}
+              name: Set up PHP
               uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
-                  php-version: ${{ matrix.php }}
+                  php-version: '8.3'
                   tools: composer:v2
 
             - name: Validate composer.json and composer.lock
               run: composer validate
-
-            - id: composer-cache-vars
-              name: Composer Cache Vars
-              run: |
-                  echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-                  echo "timestamp=$(date +"%s")" >> $GITHUB_OUTPUT
-
-            - id: composer-cache-dependencies
-              name: Cache Composer dependencies
-              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-              with:
-                  path: ${{ steps.composer-cache-vars.outputs.dir }}
-                  key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ steps.composer-cache-vars.outputs.timestamp }}
-                  restore-keys: |
-                      ${{ runner.os }}-composer-${{ matrix.php }}-
-                      ${{ runner.os }}-composer-
 
             - id: install
               name: Install dependencies
@@ -63,69 +51,34 @@ jobs:
                   composer install --no-progress --no-interaction
                   npm ci
 
-            - id: php-lint
-              name: PHP Lint
-              if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:php:lint
-
             - id: js-lint
               name: JS Lint
               if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:js:lint
+              run: composer ci:test:js:lint
 
             - id: js-format
               name: JS Format
               if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:js:format
+              run: composer ci:test:js:format
 
             - id: js-typecheck
               name: JS Typecheck
               if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:js:typecheck
-
-            - id: phpstan
-              name: PHPStan
-              if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:php:phpstan -- --error-format=github
-
-            - id: rector
-              name: Rector
-              if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:php:rector
-
-            - id: cpd
-              name: Copy/Paste Detection
-              if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:cpd
-
-            - id: php-unit
-              name: PHP Unit Tests
-              if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:php:unit
+              run: composer ci:test:js:typecheck
 
             - id: js-unit
               name: JS Unit Tests
               if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:test:js:unit
+              run: composer ci:test:js:unit
 
-            - id: cgl
-              name: CGL
+            - id: cpd
+              name: Copy/Paste Detection
               if: ${{ always() && steps.install.conclusion == 'success' }}
-              run: |
-                  composer ci:cgl -- --dry-run
+              run: composer ci:test:php:cpd
 
-            # Runs LAST: 'make dist' invokes 'composer install --no-dev'
-            # which strips dev packages (php-cs-fixer, phpstan, ...) from
-            # .build/vendor. Any later composer-driven step would fail.
+            # Runs LAST: 'make dist' invokes 'composer install --no-dev' which
+            # strips the dev packages from .build/vendor, so any later
+            # composer-driven step would fail.
             - id: dist-smoke
               name: Release zip smoke test
               if: ${{ success() }}

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,22 +9,6 @@
 
 declare(strict_types=1);
 
-/**
- * This file represents the configuration for Code Sniffing PSR-2-related
- * automatic checks of coding guidelines Install @fabpot's great php-cs-fixer
- * tool via
- *
- *  $ composer global require friendsofphp/php-cs-fixer
- *
- * And then simply run
- *
- *  $ php-cs-fixer fix
- *
- * For more information read:
- *  http://www.php-fig.org/psr/psr-2/
- *  http://cs.sensiolabs.org
- */
-
 if (PHP_SAPI !== 'cli') {
     die('This script supports command line usage only. Please check your command.');
 }
@@ -36,87 +20,10 @@ For the full copyright and license information, please read the
 LICENSE file that was distributed with this source code.
 EOF;
 
-return (new PhpCsFixer\Config())
-    ->setCacheFile(__DIR__ . '/.build/cache/.php-cs-fixer.cache')
-    ->setRiskyAllowed(true)
-    ->setParallelConfig(new PhpCsFixer\Runner\Parallel\ParallelConfig(4, 8))
-    ->setRules([
-        '@PER-CS2x0'                      => true,
-        '@Symfony'                        => true,
+$factory = require __DIR__ . '/.build/vendor/magicsunday/coding-standard/php-cs-fixer/base.php';
 
-        // Additional custom rules
-        'declare_strict_types'            => true,
-        'concat_space'                    => [
-            'spacing' => 'one',
-        ],
-        'header_comment'                  => [
-            'header'       => $header,
-            'comment_type' => 'PHPDoc',
-            'location'     => 'after_open',
-            'separate'     => 'both',
-        ],
-        'method_argument_space'           => [
-            'on_multiline' => 'ensure_fully_multiline',
-        ],
-        'phpdoc_to_comment'               => false,
-        'phpdoc_no_alias_tag'             => false,
-        'phpdoc_annotation_without_dot'   => false,
-        'no_superfluous_phpdoc_tags'      => false,
-        'phpdoc_separation'               => [
-            'groups' => [
-                [
-                    'author',
-                    'license',
-                    'link',
-                ],
-            ],
-        ],
-        'no_alias_functions'              => true,
-        'whitespace_after_comma_in_array' => [
-            'ensure_single_space' => true,
-        ],
-        'single_line_throw'               => false,
-        'self_accessor'                   => false,
-        'global_namespace_import'         => [
-            'import_classes'   => true,
-            'import_constants' => true,
-            'import_functions' => true,
-        ],
-        'function_declaration'            => [
-            'closure_function_spacing' => 'one',
-            'closure_fn_spacing'       => 'one',
-        ],
-        'binary_operator_spaces'          => [
-            'operators' => [
-                '='   => 'align_single_space_minimal',
-                '=>'  => 'align_single_space_minimal',
-                '+='  => 'align_single_space_minimal',
-                '-='  => 'align_single_space_minimal',
-                '.='  => 'align_single_space_minimal',
-                '??=' => 'align_single_space_minimal',
-            ],
-        ],
-        'yoda_style'                      => [
-            'equal'                => false,
-            'identical'            => false,
-            'less_and_greater'     => false,
-            'always_move_variable' => false,
-        ],
-        'blank_line_before_statement'     => [
-            'statements' => [
-                'break',
-                'continue',
-                'for',
-                'foreach',
-                'if',
-                'return',
-                'switch',
-                'throw',
-                'try',
-                'while',
-            ],
-        ],
-    ])
+return $factory($header)
+    ->setCacheFile(__DIR__ . '/.build/cache/.php-cs-fixer.cache')
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->exclude([

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ This repository hosts the webtrees fan chart module — an interactive SVG fan c
 
 ## Build & tests
 - **`composer ci:test` MUST run before every commit** — catches Biome lint, PHPStan, PHP-CS-Fixer, Rector, PHPUnit, Jest, and jscpd issues before they reach GitHub CI.
-- Individual checks: `composer ci:test:php:phpstan`, `composer ci:test:php:unit`, `composer ci:test:php:cgl`, `composer ci:test:js:lint`, `composer ci:test:js:unit`, `composer ci:test:cpd` (PHP + JS duplicate detection).
+- Individual checks: `composer ci:test:php:phpstan`, `composer ci:test:php:unit`, `composer ci:test:php:cgl`, `composer ci:test:js:lint`, `composer ci:test:js:unit`, `composer ci:test:php:cpd` (PHP + JS duplicate detection).
 - Single PHPUnit test: `composer ci:test:php:unit -- --filter TestClassName`.
 - Auto-fix: `composer ci:cgl` (PHP style), `composer ci:rector` (Rector), `npm run lint:fix` + `npm run format` (Biome).
 - JS bundles: `make build` (rollup), `make watch` (dev rebuild loop).

--- a/composer.json
+++ b/composer.json
@@ -57,14 +57,7 @@
         "magicsunday/webtrees-module-installer-plugin": "^2.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.0",
-        "overtrue/phplint": "^9.0",
-        "phpstan/phpstan": "^2.0",
-        "phpstan/phpstan-deprecation-rules": "^2.0",
-        "phpstan/phpstan-phpunit": "^2.0",
-        "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^12.0 || ^13.0",
-        "rector/rector": "^2.0"
+        "magicsunday/coding-standard": "^1.3"
     },
     "autoload": {
         "psr-4": {
@@ -95,7 +88,7 @@
         "ci:test:php:rector": [
             "@ci:rector --dry-run"
         ],
-        "ci:test:cpd": [
+        "ci:test:php:cpd": [
             "npx jscpd src resources/js/modules --config .jscpd.json --skip-comments --no-tips"
         ],
         "ci:test:php:unit": [
@@ -123,7 +116,7 @@
             "@ci:test:js:typecheck",
             "@ci:test:php:phpstan",
             "@ci:test:php:rector",
-            "@ci:test:cpd",
+            "@ci:test:php:cpd",
             "@ci:test:php:unit",
             "@ci:test:js:unit",
             "@ci:test:php:cgl"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,13 +1,7 @@
 includes:
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-strict-rules/rules.neon
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-deprecation-rules/rules.neon
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-phpunit/extension.neon
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-phpunit/rules.neon
+    - %currentWorkingDirectory%/.build/vendor/magicsunday/coding-standard/phpstan/base.neon
 
 parameters:
-    # You can currently choose from 11 levels (0 is the loosest and 10 is the strictest).
-    level: max
-
     # PHP Version to check against (PHP 8.3 as minimum target)
     phpVersion: 80300
 
@@ -16,9 +10,6 @@ parameters:
     paths:
         - %currentWorkingDirectory%/src/
         - %currentWorkingDirectory%/tests/
-
-    fileExtensions:
-        - php
 
     excludePaths:
         - %currentWorkingDirectory%/.build/

--- a/rector.php
+++ b/rector.php
@@ -9,13 +9,7 @@
 
 declare(strict_types=1);
 
-use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
 use Rector\Config\RectorConfig;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
-use Rector\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector;
-use Rector\Set\ValueObject\LevelSetList;
-use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
@@ -25,59 +19,7 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->fileExtensions(['php', 'phtml']);
-
-    if (
-        !is_dir($concurrentDirectory = __DIR__ . '/.build/cache/.rector.cache')
-        && !mkdir($concurrentDirectory, 0775, true)
-        && !is_dir($concurrentDirectory)
-    ) {
-        throw new \RuntimeException(
-            sprintf(
-                'Directory "%s" was not created',
-                $concurrentDirectory
-            )
-        );
-    }
-
-    if (
-        !is_dir($concurrentDirectory = __DIR__ . '/.build/cache/.rector.container.cache')
-        && !mkdir($concurrentDirectory, 0775, true)
-        && !is_dir($concurrentDirectory)
-    ) {
-        throw new \RuntimeException(
-            sprintf(
-                'Directory "%s" was not created',
-                $concurrentDirectory
-            )
-        );
-    }
-
     $rectorConfig->phpstanConfig(__DIR__ . '/phpstan.neon');
-    $rectorConfig->importNames();
-    $rectorConfig->removeUnusedImports();
-    $rectorConfig->disableParallel();
-    $rectorConfig->cacheDirectory(__DIR__ . '/.build/cache/.rector.cache');
-    $rectorConfig->containerCacheDirectory(__DIR__ . '/.build/cache/.rector.container.cache');
-    $rectorConfig->phpVersion(80300);
 
-    // Define what rule sets will be applied
-    $rectorConfig->sets([
-        SetList::CODE_QUALITY,
-        SetList::CODING_STYLE,
-        SetList::DEAD_CODE,
-        SetList::EARLY_RETURN,
-        SetList::INSTANCEOF,
-        SetList::PRIVATIZATION,
-        SetList::TYPE_DECLARATION,
-        SetList::TYPE_DECLARATION_DOCBLOCKS,
-        LevelSetList::UP_TO_PHP_83,
-    ]);
-
-    // Skip some rules
-    $rectorConfig->skip([
-        CatchExceptionNameMatchingTypeRector::class,
-        RemoveUnreachableStatementRector::class,
-        RemoveUselessParamTagRector::class,
-        RemoveUselessReturnTagRector::class,
-    ]);
+    (require __DIR__ . '/.build/vendor/magicsunday/coding-standard/rector/base.php')($rectorConfig, 80300);
 };


### PR DESCRIPTION
Closes #285.

Replaces the per-repo PHP tooling configs with the shared `magicsunday/coding-standard` package (`^1.3`), so the PHPStan / php-cs-fixer / Rector / phplint rule sets and PHPUnit live in one place and cannot drift between the chart modules. Mirrors the pedigree-chart and descendants-chart adoptions.

## Changes
- `require-dev` collapses to `magicsunday/coding-standard: ^1.3` — the individual tool packages and `phpunit/phpunit` now arrive transitively through the package (composer resolves PHPUnit per platform: 8.3 -> 12, 8.4/8.5 -> 13).
- `phpstan.neon`, `rector.php`, `.php-cs-fixer.dist.php` point at the shared base configs; `rector.php` states the PHP floor once via `(require '.../rector/base.php')($config, 80300)`.
- PHP CI gates move onto the reusable `magicsunday/.github/.github/workflows/php-quality.yml@main`; the repository-local JS lane (jscpd, npm lint/format/typecheck/unit, release-zip smoke) stays.
- `ci:test:cpd` renamed to `ci:test:php:cpd`.

## Verification
PHP gates run green via the buildbox on the published coding-standard 1.3.0:

| Gate | Result |
|---|---|
| phplint | OK (11 files) |
| phpstan | No errors |
| rector (dry) | clean |
| php-cs-fixer (dry) | 0 of 31 fixable (no reformatting) |
| phpunit | OK (46 tests, 115 assertions) |

The phpat architecture rules build on this foundation and land as a follow-up (#279).