### PR TITLE
GH-279: Enforce the module's layer boundaries with phpat

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,3 +13,9 @@ parameters:
 
     excludePaths:
         - %currentWorkingDirectory%/.build/
+
+services:
+    -
+        class: MagicSunday\Webtrees\FanChart\Test\Architecture\ArchitectureTest
+        tags:
+            - phpat.test

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,6 +15,9 @@
     <testsuites>
         <testsuite name="Unit Tests">
             <directory>tests</directory>
+            <!-- The phpat ArchitectureTest is a PHPStan rule class, not a PHPUnit
+                 test — exclude it so PHPUnit does not warn on a non-TestCase. -->
+            <exclude>tests/Architecture</exclude>
         </testsuite>
     </testsuites>
 

--- a/tests/Architecture/ArchitectureTest.php
+++ b/tests/Architecture/ArchitectureTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * This file is part of the package magicsunday/webtrees-fan-chart.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MagicSunday\Webtrees\FanChart\Test\Architecture;
+
+use PHPat\Selector\Selector;
+use PHPat\Test\Attributes\TestRule;
+use PHPat\Test\Builder\Rule;
+use PHPat\Test\PHPat;
+
+/**
+ * Architecture rules enforced by PHPat (runs as part of PHPStan).
+ *
+ * The module is layered bottom-up: `Model` and `Configuration` are leaves,
+ * `Traits` may reach `Configuration`, `Facade` may reach `Configuration` and
+ * `Model`, and `Module` is the composition root nothing else depends on. The
+ * rules below pin exactly that, so a dependency that inverts the layering reds
+ * the build instead of quietly settling in.
+ *
+ * Note on the builder: several selectors passed to `classes()` are OR-ed, so a
+ * "everything except X" set is expressed with the dedicated `excluding()` step,
+ * never with a negated selector inside `classes()`.
+ *
+ * Scope limit: the `Traits` layer cannot be the SUBJECT of a rule. phpat resolves
+ * a subject through PHPStan's `InClassNode`, which never fires for a trait on its
+ * own, so such a rule matches nothing and passes green regardless — it would imply
+ * coverage that does not exist. The traits stay pinned in the incoming direction
+ * (the leaf rules below forbid the other layers from depending on them); only
+ * their outgoing dependencies are unenforceable here.
+ *
+ * @internal
+ */
+final class ArchitectureTest
+{
+    /**
+     * The module's root namespace.
+     */
+    private const string NAMESPACE_ROOT = 'MagicSunday\Webtrees\FanChart';
+
+    /**
+     * Every abstract class carries the `Abstract` name prefix. The pattern is
+     * matched against the fully qualified name, so `[^\\]*$` pins it to the
+     * short class name rather than any namespace segment.
+     *
+     * @return Rule
+     */
+    #[TestRule]
+    public function abstractClassesAreAbstractPrefixed(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::isAbstract())
+            ->should()->beNamed('/\\\\Abstract[^\\\\]*$/', true)
+            ->because('House rule: abstract classes are named Abstract<Name>.');
+    }
+
+    /**
+     * The chart node models carry data only — they must not reach back into the
+     * configuration, the facade, the traits or the module.
+     *
+     * @return Rule
+     */
+    #[TestRule]
+    public function modelIsALeaf(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Model'))
+            ->shouldNot()->dependOn()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
+            ->excluding(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Model'))
+            ->because('Model holds chart data; it is the bottom layer.');
+    }
+
+    /**
+     * The resolved chart configuration is a leaf as well: it reads module
+     * settings, it does not consume any other part of the module.
+     *
+     * @return Rule
+     */
+    #[TestRule]
+    public function configurationIsALeaf(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::classname(self::NAMESPACE_ROOT . '\\Configuration'))
+            ->shouldNot()->dependOn()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
+            ->excluding(Selector::classname(self::NAMESPACE_ROOT . '\\Configuration'))
+            ->because('Configuration is a settings holder, not a consumer of the module.');
+    }
+
+    /**
+     * The data facade builds the chart models from the resolved configuration.
+     * It must not reach the module traits or the module class.
+     *
+     * @return Rule
+     */
+    #[TestRule]
+    public function facadeDependsOnlyOnConfigurationAndModel(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Facade'))
+            ->shouldNot()->dependOn()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
+            ->excluding(
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Facade'),
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Model'),
+                Selector::classname(self::NAMESPACE_ROOT . '\\Configuration')
+            )
+            ->because('The facade turns Configuration plus webtrees data into Model objects.');
+    }
+
+    /**
+     * The module class is the composition root — the webtrees entry point that
+     * wires the rest together. No production class may depend on it. The test
+     * namespace is excluded: a test for the module class necessarily names it.
+     *
+     * @return Rule
+     */
+    #[TestRule]
+    public function nothingDependsOnTheModule(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
+            ->excluding(
+                Selector::classname(self::NAMESPACE_ROOT . '\\Module'),
+                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Test')
+            )
+            ->shouldNot()->dependOn()
+            ->classes(Selector::classname(self::NAMESPACE_ROOT . '\\Module'))
+            ->because('Module is the composition root; dependencies point away from it.');
+    }
+}


### PR DESCRIPTION
Closes #279.

Adds a phpat `ArchitectureTest` (run as part of PHPStan through the shared coding-standard base) that pins the module's bottom-up layering, so a dependency that inverts the layers reds the build instead of quietly settling in. Builds on the coding-standard adoption (#285) which already wires phpat into the PHPStan run.

## Rules (5)
- `abstractClassesAreAbstractPrefixed` — house `Abstract<Name>` naming
- `modelIsALeaf` — `Model` depends on nothing else in the module
- `configurationIsALeaf` — `Configuration` is a settings holder, not a consumer
- `facadeDependsOnlyOnConfigurationAndModel` — the facade may reach only Configuration + Model
- `nothingDependsOnTheModule` — `Module` is the composition root

The `Traits` layer is deliberately **not** a rule subject: phpat resolves a subject through PHPStan's `InClassNode`, which never fires for a trait, so such a rule would pass green while enforcing nothing (the lesson from pedigree #155/#156). The traits stay pinned in the *incoming* direction by the leaf rules.

## Verification
The rules are proven to actually fire (a green PHPStan run alone does not prove that) via the buildbox:

| Step | Result |
|---|---|
| Baseline PHPStan | No errors (phpat loaded) |
| Probe: a `Model` class depending on `Configuration` | `[ERROR] phpat.modelIsALeaf` — rule fired |
| Probe removed | No errors again |
| PHPUnit (Architecture excluded) | OK (46 tests, 115 assertions) |

Mirrors the pedigree-chart adoption (#152/#156); the layer structure is identical, so the rules apply verbatim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated architecture checks to verify consistent module boundaries, dependency direction, and abstract class naming.
  * Updated test configuration so architecture rules run through the appropriate analysis process without generating unrelated test warnings.

* **Chores**
  * Strengthened automated quality safeguards to help maintain a more reliable and maintainable codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->