### PR TITLE
GH-290: Wire the phpat subject-liveness guard (coding-standard 1.5.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "magicsunday/webtrees-module-installer-plugin": "^2.0"
     },
     "require-dev": {
-        "magicsunday/coding-standard": "^1.4"
+        "magicsunday/coding-standard": "^1.5"
     },
     "autoload": {
         "psr-4": {
@@ -118,12 +118,16 @@
             "@ci:test:php:rector",
             "@ci:test:php:cpd",
             "@ci:test:php:templates",
+            "@ci:test:php:phpat-subjects",
             "@ci:test:php:unit",
             "@ci:test:js:unit",
             "@ci:test:php:cgl"
         ],
         "ci:test:php:templates": [
             "check-consumer-config.php ."
+        ],
+        "ci:test:php:phpat-subjects": [
+            "check-phpat-subjects.php ."
         ]
     }
 }


### PR DESCRIPTION
Closes #290.

coding-standard 1.5.0 ships `check-phpat-subjects.php`, asserting every phpat `#[TestRule]` subject matches a real class — catching a rule that silently enforces nothing.

## Changes
- `magicsunday/coding-standard` → `^1.5`.
- Add a `ci:test:php:phpat-subjects` script (`check-phpat-subjects.php .`) wired into the `ci:test` aggregate.

## Verification (buildbox, coding-standard 1.5.0)
- `ci:test:php:phpat-subjects` → `OK — every phpat rule subject matches at least one class.`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling to the latest coding-standard version.
  * Added an automated architecture validation check to the CI test suite.
  * Integrated the new check into the overall continuous integration test sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->