### PR TITLE
GH-280: Conform the module structure to the canonical Deptrac architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ __pycache__/
 
 # Playwright
 .playwright-mcp/
+/.deptrac.cache

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "magicsunday/webtrees-module-installer-plugin": "^2.0"
     },
     "require-dev": {
-        "magicsunday/coding-standard": "^1.5"
+        "magicsunday/coding-standard": "^1.6"
     },
     "autoload": {
         "psr-4": {
@@ -118,7 +118,7 @@
             "@ci:test:php:rector",
             "@ci:test:php:cpd",
             "@ci:test:php:templates",
-            "@ci:test:php:phpat-subjects",
+            "@ci:test:php:deptrac",
             "@ci:test:php:unit",
             "@ci:test:js:unit",
             "@ci:test:php:cgl"
@@ -126,8 +126,8 @@
         "ci:test:php:templates": [
             "check-consumer-config.php ."
         ],
-        "ci:test:php:phpat-subjects": [
-            "check-phpat-subjects.php ."
+        "ci:test:php:deptrac": [
+            "deptrac analyse --no-progress"
         ]
     }
 }

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -1,0 +1,30 @@
+# Deptrac configuration — imports the shared magicsunday/coding-standard ruleset.
+# This repository installs its dev tooling into .build/vendor, so the import path
+# points there (as the PHPStan include does).
+imports:
+    - .build/vendor/magicsunday/coding-standard/deptrac/layers.yaml
+
+deptrac:
+    paths:
+        - src
+
+    # `Facade\` and `Model\` are canonical (the shared directory layers cover them),
+    # and the Module-behaviour traits now live under `Module\` (also directory-covered).
+    # The `Module` and `Configuration` entry classes stay at the source root — a single
+    # class is its own layer, and moving it into a same-named subdirectory would only
+    # produce a redundant `Module/Module.php` and churn the entry FQCN — so each is
+    # mapped to its canonical layer by an exact FQCN (which cannot collide with a vendor
+    # class).
+    layers:
+        -
+            name: Module
+            collectors:
+                -
+                    type: classNameRegex
+                    value: '#^MagicSunday\\Webtrees\\FanChart\\Module$#'
+        -
+            name: Configuration
+            collectors:
+                -
+                    type: classNameRegex
+                    value: '#^MagicSunday\\Webtrees\\FanChart\\Configuration$#'

--- a/resources/lang/af/messages.po
+++ b/resources/lang/af/messages.po
@@ -122,7 +122,7 @@ msgstr "Voer as SVG uit"
 msgid "Fan chart"
 msgstr "Waaierdiagram"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "%s se waaierdiagram"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Wissel tussen volskerm en normale aansig"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/cs/messages.po
+++ b/resources/lang/cs/messages.po
@@ -121,7 +121,7 @@ msgstr "Exportovat jako SVG"
 msgid "Fan chart"
 msgstr "Vějířový diagram"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Vějíř předků osoby %s"
@@ -341,7 +341,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Přepnout mezi celou obrazovkou a normálním zobrazením"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/de/messages.po
+++ b/resources/lang/de/messages.po
@@ -122,7 +122,7 @@ msgstr "Als SVG exportieren"
 msgid "Fan chart"
 msgstr "Fächerdiagramm"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Fächerdiagramm von %s"
@@ -347,7 +347,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Zwischen Vollbildmodus und normaler Ansicht umschalten"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/en-GB/messages.po
+++ b/resources/lang/en-GB/messages.po
@@ -122,7 +122,7 @@ msgstr "Export as SVG"
 msgid "Fan chart"
 msgstr "Fan chart"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Fan chart of %s"
@@ -344,7 +344,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Switch between full screen mode and normal view"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr "The preferences for the module “%s” have been updated."

--- a/resources/lang/en-US/messages.po
+++ b/resources/lang/en-US/messages.po
@@ -122,7 +122,7 @@ msgstr "Export as SVG"
 msgid "Fan chart"
 msgstr "Fan chart"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Fan chart of %s"
@@ -344,7 +344,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Switch between full screen mode and normal view"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr "The preferences for the module “%s” have been updated."

--- a/resources/lang/es/messages.po
+++ b/resources/lang/es/messages.po
@@ -123,7 +123,7 @@ msgstr "Exportar como SVG"
 msgid "Fan chart"
 msgstr "Diagrama en abanico"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Diagrama en abanico de %s"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Cambiar entre pantalla completa y vista normal"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/fi/messages.po
+++ b/resources/lang/fi/messages.po
@@ -122,7 +122,7 @@ msgstr "Vie SVG-muodossa"
 msgid "Fan chart"
 msgstr "Esipolvi-viuhkakaavio"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Esipolvi-viuhkakaavio - %s"
@@ -343,7 +343,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Vaihda kokoruudun ja normaalinäkymän välillä"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/fr/messages.po
+++ b/resources/lang/fr/messages.po
@@ -124,7 +124,7 @@ msgstr "Exporter au format SVG"
 msgid "Fan chart"
 msgstr "Éventail des ancêtres"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Éventail des ancêtres de %s"
@@ -347,7 +347,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Basculer entre le plein écran et la vue normale"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/he/messages.po
+++ b/resources/lang/he/messages.po
@@ -121,7 +121,7 @@ msgstr "ייצא כ-SVG"
 msgid "Fan chart"
 msgstr "תרשים מניפה של אבות"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "תרשים מניפה של אבות של %s"
@@ -338,7 +338,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "החלף בין מסך מלא לתצוגה רגילה"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/hi/messages.po
+++ b/resources/lang/hi/messages.po
@@ -119,7 +119,7 @@ msgstr "SVG निकालें"
 msgid "Fan chart"
 msgstr "फैन चार्ट"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "%s का फैन चार्ट"
@@ -337,7 +337,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "पूर्ण स्क्रीन और सामान्य दृश्य के बीच स्विच करें"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/is/messages.po
+++ b/resources/lang/is/messages.po
@@ -122,7 +122,7 @@ msgstr "Flytja út sem SVG"
 msgid "Fan chart"
 msgstr "Forfeðraskífa"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Forfeðraskífa fyrir %s"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Skiptu á milli fullskjás og venjulegs skjás"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr "Kjörstillingar fyrir eininguna “%s” hafa verið uppfærðar."

--- a/resources/lang/it/messages.po
+++ b/resources/lang/it/messages.po
@@ -123,7 +123,7 @@ msgstr "Esporta come SVG"
 msgid "Fan chart"
 msgstr "Grafico a ventaglio"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Grafico a ventaglio di %s"
@@ -344,7 +344,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Passa dalla modalità a schermo intero alla visualizzazione normale"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr "Le preferenze per il modulo \"%s\" sono state aggiornate."

--- a/resources/lang/nb/messages.po
+++ b/resources/lang/nb/messages.po
@@ -121,7 +121,7 @@ msgstr "Eksporter som SVG"
 msgid "Fan chart"
 msgstr "Viftediagram"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Viftediagram til %s"
@@ -341,7 +341,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Bytt mellom fullskjerm og normal visning"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/nl/messages.po
+++ b/resources/lang/nl/messages.po
@@ -122,7 +122,7 @@ msgstr "Exporteren als SVG"
 msgid "Fan chart"
 msgstr "Waaierdiagram"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Waaierdiagram van %s"
@@ -347,7 +347,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Schakelen tussen volledig scherm en normale weergave"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr "De voorkeuren voor de module \"%s\" zijn bijgewerkt."

--- a/resources/lang/nn/messages.po
+++ b/resources/lang/nn/messages.po
@@ -121,7 +121,7 @@ msgstr "Eksporter som SVG"
 msgid "Fan chart"
 msgstr "Viftediagram"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Viftediagram til %s"
@@ -340,7 +340,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Byt mellom fullskjerm og normal visning"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/pt/messages.po
+++ b/resources/lang/pt/messages.po
@@ -122,7 +122,7 @@ msgstr "Exportar como SVG"
 msgid "Fan chart"
 msgstr "Diagrama em leque"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Diagrama em leque de %s"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Alternar entre vista em ecrã completo e vista normal"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr "As preferências do módulo \"%s\" foram atualizadas."

--- a/resources/lang/ru/messages.po
+++ b/resources/lang/ru/messages.po
@@ -122,7 +122,7 @@ msgstr "Экспорт в SVG"
 msgid "Fan chart"
 msgstr "Веерный график"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Веерный график для %s"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Переключение между полноэкранным и обычным режимом"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/sl/messages.po
+++ b/resources/lang/sl/messages.po
@@ -124,7 +124,7 @@ msgstr "Izvozi kot SVG"
 msgid "Fan chart"
 msgstr "Pahljačasti diagram"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Pahljačasti diagram osebe %s"
@@ -343,7 +343,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Preklopi med celozaslonskim in običajnim načinom"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr "Nastavitve modula “%s” so posodobljene."

--- a/resources/lang/sr-Latn/messages.po
+++ b/resources/lang/sr-Latn/messages.po
@@ -121,7 +121,7 @@ msgstr "Izvezi kao SVG"
 msgid "Fan chart"
 msgstr "Lepeza grafikon"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Lepeza grafikon %s"
@@ -341,7 +341,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Prebacivanje između celog ekrana i običnog prikaza"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/sr/messages.po
+++ b/resources/lang/sr/messages.po
@@ -121,7 +121,7 @@ msgstr "Извези као SVG"
 msgid "Fan chart"
 msgstr "Лепеза графикон"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Лепеза графикон %s"
@@ -341,7 +341,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Пребацивање између целог екрана и обичног приказа"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/sv/messages.po
+++ b/resources/lang/sv/messages.po
@@ -123,7 +123,7 @@ msgstr "Exportera som SVG"
 msgid "Fan chart"
 msgstr "Solfjäderdiagram"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Solfjäderdiagram för %s"
@@ -343,7 +343,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Växla mellan helskärm och normal vy"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/uk/messages.po
+++ b/resources/lang/uk/messages.po
@@ -122,7 +122,7 @@ msgstr "Експорт в SVG"
 msgid "Fan chart"
 msgstr "Віяловий графік"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Віяловий графік для %s"
@@ -342,7 +342,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Перемикання між повноекранним і звичайним режимом"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/vi/messages.po
+++ b/resources/lang/vi/messages.po
@@ -121,7 +121,7 @@ msgstr "Xuất định dạng SVG"
 msgid "Fan chart"
 msgstr "Biểu đồ hình quạt"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "Biểu đồ hình quạt của %s"
@@ -340,7 +340,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "Chuyển giữa toàn màn hình và xem bình thường"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/zh-Hans/messages.po
+++ b/resources/lang/zh-Hans/messages.po
@@ -117,7 +117,7 @@ msgstr "导出为 SVG"
 msgid "Fan chart"
 msgstr "扇形图"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "%s的扇形图"
@@ -330,7 +330,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "切换全屏与普通视图"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/resources/lang/zh-Hant/messages.po
+++ b/resources/lang/zh-Hant/messages.po
@@ -117,7 +117,7 @@ msgstr "匯出為 SVG"
 msgid "Fan chart"
 msgstr "扇形圖"
 
-#: src/Module.php:233 src/Traits/ModuleChartTrait.php:46
+#: src/Module.php:233 src/Module/ChartTrait.php:46
 #, php-format
 msgid "Fan chart of %s"
 msgstr "%s的扇形圖"
@@ -330,7 +330,7 @@ msgstr ""
 msgid "Switch between full screen mode and normal view"
 msgstr "切換全螢幕與一般檢視"
 
-#: src/Traits/ModuleConfigTrait.php:146
+#: src/Module/ConfigTrait.php:147
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
 msgstr ""

--- a/src/Module.php
+++ b/src/Module.php
@@ -30,8 +30,8 @@ use Fisharebest\Webtrees\Services\ChartService;
 use Fisharebest\Webtrees\Validator;
 use Fisharebest\Webtrees\View;
 use MagicSunday\Webtrees\FanChart\Facade\DataFacade;
-use MagicSunday\Webtrees\FanChart\Traits\ModuleChartTrait;
-use MagicSunday\Webtrees\FanChart\Traits\ModuleConfigTrait;
+use MagicSunday\Webtrees\FanChart\Module\ChartTrait;
+use MagicSunday\Webtrees\FanChart\Module\ConfigTrait;
 use MagicSunday\Webtrees\ModuleBase\Contract\ModuleAssetUrlInterface;
 use MagicSunday\Webtrees\ModuleBase\Traits\ModuleCustomTrait;
 use Override;
@@ -53,8 +53,8 @@ use Psr\Http\Message\ServerRequestInterface;
 class Module extends FanChartModule implements ModuleAssetUrlInterface, ModuleCustomInterface, ModuleConfigInterface
 {
     use ModuleCustomTrait;
-    use ModuleChartTrait;
-    use ModuleConfigTrait;
+    use ChartTrait;
+    use ConfigTrait;
 
     private const string ROUTE_DEFAULT = 'webtrees-fan-chart';
 

--- a/src/Module/ChartTrait.php
+++ b/src/Module/ChartTrait.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace MagicSunday\Webtrees\FanChart\Traits;
+namespace MagicSunday\Webtrees\FanChart\Module;
 
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Individual;
@@ -23,7 +23,7 @@ use MagicSunday\Webtrees\ModuleBase\Traits\ModuleChartTrait as BaseModuleChartTr
  * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
  * @link    https://github.com/magicsunday/webtrees-fan-chart/
  */
-trait ModuleChartTrait
+trait ChartTrait
 {
     use BaseModuleChartTrait;
 

--- a/src/Module/ConfigTrait.php
+++ b/src/Module/ConfigTrait.php
@@ -9,10 +9,11 @@
 
 declare(strict_types=1);
 
-namespace MagicSunday\Webtrees\FanChart\Traits;
+namespace MagicSunday\Webtrees\FanChart\Module;
 
 use Fisharebest\Webtrees\FlashMessages;
 use Fisharebest\Webtrees\I18N;
+use Fisharebest\Webtrees\Module\ModuleConfigTrait;
 use MagicSunday\Webtrees\FanChart\Configuration;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -25,9 +26,9 @@ use Psr\Http\Message\ServerRequestInterface;
  * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
  * @link    https://github.com/magicsunday/webtrees-fan-chart/
  */
-trait ModuleConfigTrait
+trait ConfigTrait
 {
-    use \Fisharebest\Webtrees\Module\ModuleConfigTrait;
+    use ModuleConfigTrait;
 
     /**
      * Renders the module configuration form in the webtrees administration

--- a/tests/Architecture/ArchitectureTest.php
+++ b/tests/Architecture/ArchitectureTest.php
@@ -19,32 +19,16 @@ use PHPat\Test\PHPat;
 /**
  * Architecture rules enforced by PHPat (runs as part of PHPStan).
  *
- * The module is layered bottom-up: `Model` and `Configuration` are leaves,
- * `Traits` may reach `Configuration`, `Facade` may reach `Configuration` and
- * `Model`, and `Module` is the composition root nothing else depends on. The
- * rules below pin exactly that, so a dependency that inverts the layering reds
- * the build instead of quietly settling in.
- *
- * Note on the builder: several selectors passed to `classes()` are OR-ed, so a
- * "everything except X" set is expressed with the dedicated `excluding()` step,
- * never with a negated selector inside `classes()`.
- *
- * Scope limit: the `Traits` layer cannot be the SUBJECT of a rule. phpat resolves
- * a subject through PHPStan's `InClassNode`, which never fires for a trait on its
- * own, so such a rule matches nothing and passes green regardless — it would imply
- * coverage that does not exist. The traits stay pinned in the incoming direction
- * (the leaf rules below forbid the other layers from depending on them); only
- * their outgoing dependencies are unenforceable here.
+ * The layer-DEPENDENCY directions (Model/Configuration are leaves, the facade
+ * reaches only Configuration and Model, nothing depends on the composition root)
+ * are now enforced centrally by the shared Deptrac ruleset (`deptrac.yaml` imports
+ * `magicsunday/coding-standard`'s canonical layers). What remains here is the one
+ * structural invariant Deptrac's layer model cannot express.
  *
  * @internal
  */
 final class ArchitectureTest
 {
-    /**
-     * The module's root namespace.
-     */
-    private const string NAMESPACE_ROOT = 'MagicSunday\Webtrees\FanChart';
-
     /**
      * Every abstract class carries the `Abstract` name prefix. The pattern is
      * matched against the fully qualified name, so `[^\\]*$` pins it to the
@@ -59,81 +43,5 @@ final class ArchitectureTest
             ->classes(Selector::isAbstract())
             ->should()->beNamed('/\\\\Abstract[^\\\\]*$/', true)
             ->because('House rule: abstract classes are named Abstract<Name>.');
-    }
-
-    /**
-     * The chart node models carry data only — they must not reach back into the
-     * configuration, the facade, the traits or the module.
-     *
-     * @return Rule
-     */
-    #[TestRule]
-    public function modelIsALeaf(): Rule
-    {
-        return PHPat::rule()
-            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Model'))
-            ->shouldNot()->dependOn()
-            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
-            ->excluding(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Model'))
-            ->because('Model holds chart data; it is the bottom layer.');
-    }
-
-    /**
-     * The resolved chart configuration is a leaf as well: it reads module
-     * settings, it does not consume any other part of the module.
-     *
-     * @return Rule
-     */
-    #[TestRule]
-    public function configurationIsALeaf(): Rule
-    {
-        return PHPat::rule()
-            ->classes(Selector::classname(self::NAMESPACE_ROOT . '\\Configuration'))
-            ->shouldNot()->dependOn()
-            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
-            ->excluding(Selector::classname(self::NAMESPACE_ROOT . '\\Configuration'))
-            ->because('Configuration is a settings holder, not a consumer of the module.');
-    }
-
-    /**
-     * The data facade builds the chart models from the resolved configuration.
-     * It must not reach the module traits or the module class.
-     *
-     * @return Rule
-     */
-    #[TestRule]
-    public function facadeDependsOnlyOnConfigurationAndModel(): Rule
-    {
-        return PHPat::rule()
-            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT . '\\Facade'))
-            ->shouldNot()->dependOn()
-            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
-            ->excluding(
-                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Facade'),
-                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Model'),
-                Selector::classname(self::NAMESPACE_ROOT . '\\Configuration')
-            )
-            ->because('The facade turns Configuration plus webtrees data into Model objects.');
-    }
-
-    /**
-     * The module class is the composition root — the webtrees entry point that
-     * wires the rest together. No production class may depend on it. The test
-     * namespace is excluded: a test for the module class necessarily names it.
-     *
-     * @return Rule
-     */
-    #[TestRule]
-    public function nothingDependsOnTheModule(): Rule
-    {
-        return PHPat::rule()
-            ->classes(Selector::inNamespace(self::NAMESPACE_ROOT))
-            ->excluding(
-                Selector::classname(self::NAMESPACE_ROOT . '\\Module'),
-                Selector::inNamespace(self::NAMESPACE_ROOT . '\\Test')
-            )
-            ->shouldNot()->dependOn()
-            ->classes(Selector::classname(self::NAMESPACE_ROOT . '\\Module'))
-            ->because('Module is the composition root; dependencies point away from it.');
     }
 }


### PR DESCRIPTION
Closes #280.

Adopt the shared `magicsunday/coding-standard` Deptrac ruleset and make the module physically conform to the canonical layered architecture.

## What changed
- **Move + rename the two module-behaviour traits** into the `Module` layer, dropping their now-redundant prefix: `Traits\ModuleChartTrait` → `Module\ChartTrait`, `Traits\ModuleConfigTrait` → `Module\ConfigTrait`. Removing the `ModuleConfigTrait` name clash also let Rector import the webtrees `ModuleConfigTrait` it had kept fully-qualified.
- The `Module` and `Configuration` **entry classes stay at the source root** (a single class is its own layer; moving it would only produce a redundant `Module/Module.php` and churn the entry FQCN) and are mapped to their canonical layer by an exact FQCN in `deptrac.yaml`. `Facade` and `Model` are already canonical.
- Wire `ci:test:php:deptrac` (drop the superseded phpat-subjects gate); remove the four layer-dependency rules from `ArchitectureTest` (Deptrac owns them), keep the structural Abstract-prefix rule.
- Resync the PO `#:` locations (`make lang`) after the file move — location-only, no string drift.

## Verification
Deptrac **zero violations / zero warnings**; PHPStan, CGL, Rector and the template gate green; PHPUnit OK (46 tests). The `Module` FQCN is unchanged, so webtrees registration is unaffected (the `ModuleTest` exercising the moved traits passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal module components without changing public behavior or functionality.
  * Updated translation source references to match the reorganized components; translated text remains unchanged.

* **Tests**
  * Centralized architecture dependency validation and added automated layer analysis to CI.
  * Retained checks ensuring abstract classes follow the project’s naming conventions.

* **Chores**
  * Updated development tooling and excluded generated architecture-analysis cache files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->