### PR TITLE
GH-305: Add the AI issue labeler thin caller

### DIFF
--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -1,0 +1,31 @@
+name: Issue labels
+
+# Thin caller for the reusable AI issue labeler
+# (magicsunday/.github's ai-issue-labeler.yml). See that workflow's own
+# header comment for the full contract (label-set enum constraint,
+# needs-triage fallback, residual-risk acceptance).
+#
+# `uses: magicsunday/.github/.github/workflows/ai-issue-labeler.yml@main`
+# (the fully-qualified form) - a caller in a DIFFERENT repository than the
+# one that owns the reusable workflow, per that workflow's own documented
+# CALLER REQUIREMENTS block.
+#
+# REQUIRES the `ANTHROPIC_API_KEY` repository secret to be set on THIS repo
+# - this account has no org-wide secret inheritance (see
+# ai-issue-labeler.yml's own header comment for what happens, and its own
+# fail-loudly contract, when the secret is missing or invalid). That
+# failure is harmless here: it never blocks issue creation itself, since
+# `issues: write` is the only permission this caller grants.
+on:
+    issues:
+        types: [opened]
+
+permissions: {}
+
+jobs:
+    label:
+        uses: magicsunday/.github/.github/workflows/ai-issue-labeler.yml@main
+        permissions:
+            issues: write
+        secrets:
+            anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
This adds a thin caller for `magicsunday/.github`'s reusable `ai-issue-labeler.yml` workflow.

The reusable workflow classifies newly-opened issues via the Anthropic API and applies a label from this repo's own live label set, falling back to `needs-triage` on low confidence.

Part of the rollout described in `magicsunday/.github#60` step 4.

This repo already has the required `ANTHROPIC_API_KEY` repository secret and the `needs-triage` label provisioned.

The added file is byte-identical to the same caller already piloted and verified working in `magicsunday/.github` and `magicsunday/coding-standard`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newly opened issues are now automatically labeled.
  * Issue categorization is more consistent, making it easier to organize and triage incoming reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->